### PR TITLE
feat: add GraphQL API endpoint for FrooxEngine state inspection

### DIFF
--- a/Headless/Configuration/GraphQLConfig.cs
+++ b/Headless/Configuration/GraphQLConfig.cs
@@ -1,0 +1,13 @@
+namespace Headless.Configuration;
+
+public record GraphQLConfig
+(
+    bool Enabled = true,
+    string Path = "/graphql",
+    int Port = 5050
+)
+{
+    public GraphQLConfig() : this(true, "/graphql", 5050)
+    {
+    }
+}

--- a/Headless/Configuration/HeadlessStartupConfig.cs
+++ b/Headless/Configuration/HeadlessStartupConfig.cs
@@ -1,6 +1,7 @@
 using Google.Protobuf;
 using Headless.Extensions;
 using Newtonsoft.Json;
+using Path = System.IO.Path;
 
 namespace Headless.Configuration;
 

--- a/Headless/GraphQL/Mutations/ComponentMutations.cs
+++ b/Headless/GraphQL/Mutations/ComponentMutations.cs
@@ -20,9 +20,10 @@ public class ComponentMutations
         var componentType = service.FindComponentType(componentTypeName);
         if (componentType == null) return null;
 
+        if (!service.TryParseRefId(slotRefId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(slotRefId);
             var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
             if (slot == null) return null;
 
@@ -42,9 +43,13 @@ public class ComponentMutations
             return new RemoveComponentResult(false, componentRefId, null, "Session not found");
         }
 
+        if (!service.TryParseRefId(componentRefId, out var parsedRefId))
+        {
+            return new RemoveComponentResult(false, componentRefId, null, "Invalid RefID format");
+        }
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(componentRefId);
             var component = service.FindComponentByRefId(session.Instance, parsedRefId);
             if (component == null)
             {
@@ -67,9 +72,10 @@ public class ComponentMutations
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(componentRefId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(componentRefId);
             var component = service.FindComponentByRefId(session.Instance, parsedRefId);
             if (component == null) return null;
 

--- a/Headless/GraphQL/Mutations/ComponentMutations.cs
+++ b/Headless/GraphQL/Mutations/ComponentMutations.cs
@@ -1,0 +1,88 @@
+using Elements.Core;
+using FrooxEngine;
+using Headless.GraphQL.Services;
+using Headless.GraphQL.Types;
+
+namespace Headless.GraphQL.Mutations;
+
+[ExtendObjectType(OperationTypeNames.Mutation)]
+public class ComponentMutations
+{
+    public async Task<ComponentType?> AttachComponent(
+        string sessionId,
+        string slotRefId,
+        string componentTypeName,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        var componentType = service.FindComponentType(componentTypeName);
+        if (componentType == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(slotRefId);
+            var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            if (slot == null) return null;
+
+            var component = slot.AttachComponent(componentType);
+            return component != null ? new ComponentType(component) : null;
+        });
+    }
+
+    public async Task<RemoveComponentResult> RemoveComponent(
+        string sessionId,
+        string componentRefId,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null)
+        {
+            return new RemoveComponentResult(false, componentRefId, null, "Session not found");
+        }
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(componentRefId);
+            var component = service.FindComponentByRefId(session.Instance, parsedRefId);
+            if (component == null)
+            {
+                return new RemoveComponentResult(false, componentRefId, null, "Component not found");
+            }
+
+            var typeName = component.GetType().FullName ?? component.GetType().Name;
+            component.Destroy();
+
+            return new RemoveComponentResult(true, componentRefId, typeName, null);
+        });
+    }
+
+    public async Task<ComponentType?> SetComponentEnabled(
+        string sessionId,
+        string componentRefId,
+        bool enabled,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(componentRefId);
+            var component = service.FindComponentByRefId(session.Instance, parsedRefId);
+            if (component == null) return null;
+
+            component.Enabled = enabled;
+            return new ComponentType(component);
+        });
+    }
+}
+
+[ObjectType]
+public record RemoveComponentResult(
+    bool Success,
+    string RemovedRefId,
+    string? RemovedTypeName,
+    string? Error
+);

--- a/Headless/GraphQL/Mutations/SlotMutations.cs
+++ b/Headless/GraphQL/Mutations/SlotMutations.cs
@@ -18,9 +18,10 @@ public class SlotMutations
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(slotRefId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(slotRefId);
             var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
             if (slot == null) return null;
 
@@ -38,9 +39,10 @@ public class SlotMutations
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(slotRefId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(slotRefId);
             var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
             if (slot == null) return null;
 
@@ -61,9 +63,10 @@ public class SlotMutations
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(slotRefId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(slotRefId);
             var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
             if (slot == null) return null;
 
@@ -93,9 +96,10 @@ public class SlotMutations
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(slotRefId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(slotRefId);
             var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
             if (slot == null) return null;
 
@@ -124,9 +128,10 @@ public class SlotMutations
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(slotRefId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(slotRefId);
             var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
             if (slot == null) return null;
 
@@ -152,9 +157,10 @@ public class SlotMutations
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(parentSlotRefId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(parentSlotRefId);
             var parentSlot = service.FindSlotByRefId(session.Instance, parsedRefId);
             if (parentSlot == null) return null;
 
@@ -175,9 +181,13 @@ public class SlotMutations
             return new DeleteSlotResult(false, slotRefId, "Session not found");
         }
 
+        if (!service.TryParseRefId(slotRefId, out var parsedRefId))
+        {
+            return new DeleteSlotResult(false, slotRefId, "Invalid RefID format");
+        }
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(slotRefId);
             var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
             if (slot == null)
             {

--- a/Headless/GraphQL/Mutations/SlotMutations.cs
+++ b/Headless/GraphQL/Mutations/SlotMutations.cs
@@ -1,0 +1,212 @@
+using Elements.Core;
+using FrooxEngine;
+using Headless.GraphQL.Services;
+using Headless.GraphQL.Types;
+using Headless.GraphQL.Types.Scalars;
+
+namespace Headless.GraphQL.Mutations;
+
+[ExtendObjectType(OperationTypeNames.Mutation)]
+public class SlotMutations
+{
+    public async Task<SlotType?> SetSlotActive(
+        string sessionId,
+        string slotRefId,
+        bool active,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(slotRefId);
+            var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            if (slot == null) return null;
+
+            slot.ActiveSelf = active;
+            return new SlotType(slot);
+        });
+    }
+
+    public async Task<SlotType?> SetSlotName(
+        string sessionId,
+        string slotRefId,
+        string name,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(slotRefId);
+            var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            if (slot == null) return null;
+
+            slot.Name = name;
+            return new SlotType(slot);
+        });
+    }
+
+    public async Task<SlotType?> SetSlotPosition(
+        string sessionId,
+        string slotRefId,
+        float x,
+        float y,
+        float z,
+        bool global = false,
+        [Service] FrooxEngineGraphQLService service = null!)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(slotRefId);
+            var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            if (slot == null) return null;
+
+            var position = new float3(x, y, z);
+            if (global)
+            {
+                slot.GlobalPosition = position;
+            }
+            else
+            {
+                slot.LocalPosition = position;
+            }
+            return new SlotType(slot);
+        });
+    }
+
+    public async Task<SlotType?> SetSlotRotation(
+        string sessionId,
+        string slotRefId,
+        float x,
+        float y,
+        float z,
+        float w,
+        bool global = false,
+        [Service] FrooxEngineGraphQLService service = null!)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(slotRefId);
+            var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            if (slot == null) return null;
+
+            var rotation = new floatQ(x, y, z, w);
+            if (global)
+            {
+                slot.GlobalRotation = rotation;
+            }
+            else
+            {
+                slot.LocalRotation = rotation;
+            }
+            return new SlotType(slot);
+        });
+    }
+
+    public async Task<SlotType?> SetSlotScale(
+        string sessionId,
+        string slotRefId,
+        float x,
+        float y,
+        float z,
+        bool global = false,
+        [Service] FrooxEngineGraphQLService service = null!)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(slotRefId);
+            var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            if (slot == null) return null;
+
+            var scale = new float3(x, y, z);
+            if (global)
+            {
+                slot.GlobalScale = scale;
+            }
+            else
+            {
+                slot.LocalScale = scale;
+            }
+            return new SlotType(slot);
+        });
+    }
+
+    public async Task<SlotType?> AddChildSlot(
+        string sessionId,
+        string parentSlotRefId,
+        string name,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(parentSlotRefId);
+            var parentSlot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            if (parentSlot == null) return null;
+
+            var newSlot = parentSlot.AddSlot(name);
+            return new SlotType(newSlot);
+        });
+    }
+
+    public async Task<DeleteSlotResult> DeleteSlot(
+        string sessionId,
+        string slotRefId,
+        bool preserveChildren = false,
+        [Service] FrooxEngineGraphQLService service = null!)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null)
+        {
+            return new DeleteSlotResult(false, slotRefId, "Session not found");
+        }
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(slotRefId);
+            var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            if (slot == null)
+            {
+                return new DeleteSlotResult(false, slotRefId, "Slot not found");
+            }
+
+            if (slot == session.Instance.RootSlot)
+            {
+                return new DeleteSlotResult(false, slotRefId, "Cannot delete root slot");
+            }
+
+            if (preserveChildren && slot.Parent != null)
+            {
+                var children = slot.Children.ToList();
+                foreach (var child in children)
+                {
+                    child.SetParent(slot.Parent, false);
+                }
+            }
+
+            slot.Destroy();
+            return new DeleteSlotResult(true, slotRefId, null);
+        });
+    }
+}
+
+[ObjectType]
+public record DeleteSlotResult(
+    bool Success,
+    string DeletedRefId,
+    string? Error
+);

--- a/Headless/GraphQL/Mutations/SyncMemberMutations.cs
+++ b/Headless/GraphQL/Mutations/SyncMemberMutations.cs
@@ -22,9 +22,13 @@ public class SyncMemberMutations
             return new SetSyncFieldResult(false, null, null, "Session not found");
         }
 
+        if (!service.TryParseRefId(componentRefId, out var parsedRefId))
+        {
+            return new SetSyncFieldResult(false, null, null, "Invalid RefID format");
+        }
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(componentRefId);
             var component = service.FindComponentByRefId(session.Instance, parsedRefId);
             if (component == null)
             {
@@ -67,9 +71,23 @@ public class SyncMemberMutations
             return new SetSyncRefResult(false, null, null, "Session not found");
         }
 
+        if (!service.TryParseRefId(componentRefId, out var parsedRefId))
+        {
+            return new SetSyncRefResult(false, null, null, "Invalid RefID format");
+        }
+
+        RefID? parsedTargetRefId = null;
+        if (!string.IsNullOrEmpty(targetRefId))
+        {
+            if (!service.TryParseRefId(targetRefId, out var targetParsed))
+            {
+                return new SetSyncRefResult(false, null, null, "Invalid target RefID format");
+            }
+            parsedTargetRefId = targetParsed;
+        }
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(componentRefId);
             var component = service.FindComponentByRefId(session.Instance, parsedRefId);
             if (component == null)
             {
@@ -90,10 +108,6 @@ public class SyncMemberMutations
             var valueProperty = syncRef.GetType().GetProperty("Value");
             var previousRefId = valueProperty?.GetValue(syncRef) as RefID?;
             var previousRefIdStr = previousRefId?.ToString();
-
-            RefID? parsedTargetRefId = string.IsNullOrEmpty(targetRefId)
-                ? null
-                : RefID.Parse(targetRefId);
 
             if (service.SetSyncRefTarget(syncRef, parsedTargetRefId, session.Instance))
             {

--- a/Headless/GraphQL/Mutations/SyncMemberMutations.cs
+++ b/Headless/GraphQL/Mutations/SyncMemberMutations.cs
@@ -1,0 +1,122 @@
+using Elements.Core;
+using FrooxEngine;
+using Headless.GraphQL.Services;
+using Headless.GraphQL.Types;
+using IField = FrooxEngine.IField;
+
+namespace Headless.GraphQL.Mutations;
+
+[ExtendObjectType(OperationTypeNames.Mutation)]
+public class SyncMemberMutations
+{
+    public async Task<SetSyncFieldResult> SetSyncFieldValue(
+        string sessionId,
+        string componentRefId,
+        string memberName,
+        string value,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null)
+        {
+            return new SetSyncFieldResult(false, null, null, "Session not found");
+        }
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(componentRefId);
+            var component = service.FindComponentByRefId(session.Instance, parsedRefId);
+            if (component == null)
+            {
+                return new SetSyncFieldResult(false, null, null, "Component not found");
+            }
+
+            var member = component.GetSyncMember(memberName);
+            if (member == null)
+            {
+                return new SetSyncFieldResult(false, null, null, $"SyncMember '{memberName}' not found");
+            }
+
+            if (member is not IField field)
+            {
+                return new SetSyncFieldResult(false, null, null, $"SyncMember '{memberName}' is not a field");
+            }
+
+            var previousValue = field.BoxedValue?.ToString();
+
+            if (service.SetSyncFieldValue(field, value))
+            {
+                var newValue = field.BoxedValue?.ToString();
+                return new SetSyncFieldResult(true, previousValue, newValue, null);
+            }
+
+            return new SetSyncFieldResult(false, previousValue, null, "Failed to set value");
+        });
+    }
+
+    public async Task<SetSyncRefResult> SetSyncRefTarget(
+        string sessionId,
+        string componentRefId,
+        string memberName,
+        string? targetRefId,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null)
+        {
+            return new SetSyncRefResult(false, null, null, "Session not found");
+        }
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(componentRefId);
+            var component = service.FindComponentByRefId(session.Instance, parsedRefId);
+            if (component == null)
+            {
+                return new SetSyncRefResult(false, null, null, "Component not found");
+            }
+
+            var member = component.GetSyncMember(memberName);
+            if (member == null)
+            {
+                return new SetSyncRefResult(false, null, null, $"SyncMember '{memberName}' not found");
+            }
+
+            if (member is not ISyncRef syncRef)
+            {
+                return new SetSyncRefResult(false, null, null, $"SyncMember '{memberName}' is not a SyncRef");
+            }
+
+            var valueProperty = syncRef.GetType().GetProperty("Value");
+            var previousRefId = valueProperty?.GetValue(syncRef) as RefID?;
+            var previousRefIdStr = previousRefId?.ToString();
+
+            RefID? parsedTargetRefId = string.IsNullOrEmpty(targetRefId)
+                ? null
+                : RefID.Parse(targetRefId);
+
+            if (service.SetSyncRefTarget(syncRef, parsedTargetRefId, session.Instance))
+            {
+                return new SetSyncRefResult(true, previousRefIdStr, targetRefId, null);
+            }
+
+            return new SetSyncRefResult(false, previousRefIdStr, null, "Failed to set target");
+        });
+    }
+}
+
+[ObjectType]
+public record SetSyncFieldResult(
+    bool Success,
+    string? PreviousValue,
+    string? NewValue,
+    string? Error
+);
+
+[ObjectType]
+public record SetSyncRefResult(
+    bool Success,
+    string? PreviousRefId,
+    string? NewRefId,
+    string? Error
+);

--- a/Headless/GraphQL/Queries/WorldQueries.cs
+++ b/Headless/GraphQL/Queries/WorldQueries.cs
@@ -1,0 +1,103 @@
+using Elements.Core;
+using FrooxEngine;
+using Headless.GraphQL.Services;
+using Headless.GraphQL.Types;
+
+namespace Headless.GraphQL.Queries;
+
+[ExtendObjectType(OperationTypeNames.Query)]
+public class WorldQueries
+{
+    public IEnumerable<WorldType> GetWorlds([Service] FrooxEngineGraphQLService service)
+    {
+        return service.ListSessions().Select(s => new WorldType(s.Instance));
+    }
+
+    public WorldType? GetWorld(
+        string sessionId,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        return session != null ? new WorldType(session.Instance) : null;
+    }
+
+    public async Task<SlotType?> GetSlot(
+        string sessionId,
+        string refId,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(refId);
+            var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
+            return slot != null ? new SlotType(slot) : null;
+        });
+    }
+
+    public async Task<ComponentType?> GetComponent(
+        string sessionId,
+        string refId,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var session = service.GetSession(sessionId);
+        if (session == null) return null;
+
+        return await service.ExecuteOnWorldThread(session.Instance, () =>
+        {
+            var parsedRefId = RefID.Parse(refId);
+            var component = service.FindComponentByRefId(session.Instance, parsedRefId);
+            return component != null ? new ComponentType(component) : null;
+        });
+    }
+
+    public IEnumerable<ComponentTypeInfo> GetComponentTypes(
+        string? filter,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        IEnumerable<Type> types = service.GetAllComponentTypes();
+
+        if (!string.IsNullOrEmpty(filter))
+        {
+            var lowerFilter = filter.ToLowerInvariant();
+            types = types.Where(t =>
+                (t.Name?.ToLowerInvariant().Contains(lowerFilter) ?? false) ||
+                (t.FullName?.ToLowerInvariant().Contains(lowerFilter) ?? false));
+        }
+
+        return types.Select(t => new ComponentTypeInfo(t));
+    }
+}
+
+[ObjectType]
+public class ComponentTypeInfo
+{
+    private readonly Type _type;
+
+    public ComponentTypeInfo(Type type)
+    {
+        _type = type;
+    }
+
+    public string Name => _type.Name;
+    public string FullName => _type.FullName ?? _type.Name;
+    public string? Category => GetCategory();
+    public bool IsGeneric => _type.IsGenericType;
+    public string? GenericDefinition => _type.IsGenericType ? _type.GetGenericTypeDefinition().Name : null;
+
+    private string? GetCategory()
+    {
+        var ns = _type.Namespace;
+        if (ns == null) return null;
+
+        if (ns.StartsWith("FrooxEngine.ProtoFlux")) return "ProtoFlux";
+        if (ns.StartsWith("FrooxEngine.UIX")) return "UIX";
+        if (ns.StartsWith("FrooxEngine.FinalIK")) return "IK";
+        if (ns.StartsWith("FrooxEngine.CommonAvatar")) return "Avatar";
+        if (ns.StartsWith("FrooxEngine.LogiX")) return "LogiX";
+        if (ns.StartsWith("FrooxEngine")) return "Core";
+        return ns;
+    }
+}

--- a/Headless/GraphQL/Queries/WorldQueries.cs
+++ b/Headless/GraphQL/Queries/WorldQueries.cs
@@ -29,9 +29,10 @@ public class WorldQueries
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(refId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(refId);
             var slot = service.FindSlotByRefId(session.Instance, parsedRefId);
             return slot != null ? new SlotType(slot) : null;
         });
@@ -45,9 +46,10 @@ public class WorldQueries
         var session = service.GetSession(sessionId);
         if (session == null) return null;
 
+        if (!service.TryParseRefId(refId, out var parsedRefId)) return null;
+
         return await service.ExecuteOnWorldThread(session.Instance, () =>
         {
-            var parsedRefId = RefID.Parse(refId);
             var component = service.FindComponentByRefId(session.Instance, parsedRefId);
             return component != null ? new ComponentType(component) : null;
         });

--- a/Headless/GraphQL/Services/FrooxEngineGraphQLService.cs
+++ b/Headless/GraphQL/Services/FrooxEngineGraphQLService.cs
@@ -1,0 +1,195 @@
+using System.Text.Json;
+using Elements.Core;
+using FrooxEngine;
+using Headless.Models;
+using Headless.Services;
+using IField = FrooxEngine.IField;
+
+namespace Headless.GraphQL.Services;
+
+public class FrooxEngineGraphQLService
+{
+    private readonly WorldService _worldService;
+    private readonly ILogger<FrooxEngineGraphQLService> _logger;
+    private readonly Lazy<IReadOnlyList<Type>> _componentTypesCache;
+
+    public FrooxEngineGraphQLService(WorldService worldService, ILogger<FrooxEngineGraphQLService> logger)
+    {
+        _worldService = worldService;
+        _logger = logger;
+        _componentTypesCache = new Lazy<IReadOnlyList<Type>>(ScanComponentTypes);
+    }
+
+    public RunningSession? GetSession(string sessionId) => _worldService.GetSession(sessionId);
+
+    public IEnumerable<RunningSession> ListSessions() => _worldService.ListAll();
+
+    public async Task<T> ExecuteOnWorldThread<T>(World world, Func<T> action)
+    {
+        return await world.Coroutines.StartTask(async () =>
+        {
+            await default(ToWorld);
+            return action();
+        });
+    }
+
+    public async Task ExecuteOnWorldThread(World world, Func<Task> action)
+    {
+        await world.Coroutines.StartTask(async () =>
+        {
+            await default(ToWorld);
+            await action();
+        });
+    }
+
+    public async Task<T> ExecuteOnWorldThreadAsync<T>(World world, Func<Task<T>> action)
+    {
+        return await world.Coroutines.StartTask(async () =>
+        {
+            await default(ToWorld);
+            return await action();
+        });
+    }
+
+    public Slot? FindSlotByRefId(World world, RefID refId)
+    {
+        return world.ReferenceController.GetObjectOrNull(refId) as Slot;
+    }
+
+    public Component? FindComponentByRefId(World world, RefID refId)
+    {
+        return world.ReferenceController.GetObjectOrNull(refId) as Component;
+    }
+
+    public IWorldElement? FindElementByRefId(World world, RefID refId)
+    {
+        return world.ReferenceController.GetObjectOrNull(refId);
+    }
+
+    public object? GetSyncMemberValue(ISyncMember member)
+    {
+        if (member is IField field)
+        {
+            return field.BoxedValue;
+        }
+        return null;
+    }
+
+    public bool SetSyncFieldValue(IField field, string jsonValue)
+    {
+        try
+        {
+            var value = DeserializeValue(field.ValueType, jsonValue);
+            field.BoxedValue = value;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set sync field value");
+            return false;
+        }
+    }
+
+    public bool SetSyncRefTarget(ISyncRef syncRef, RefID? targetRefId, World world)
+    {
+        try
+        {
+            if (targetRefId == null || targetRefId == default(RefID))
+            {
+                var valueProperty = syncRef.GetType().GetProperty("Value");
+                valueProperty?.SetValue(syncRef, default(RefID));
+            }
+            else
+            {
+                var target = world.ReferenceController.GetObjectOrNull(targetRefId.Value);
+                if (target == null)
+                {
+                    _logger.LogWarning("Target not found for RefID: {RefId}", targetRefId);
+                    return false;
+                }
+                var targetProperty = syncRef.GetType().GetProperty("Target");
+                targetProperty?.SetValue(syncRef, target);
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set sync ref target");
+            return false;
+        }
+    }
+
+    private object? DeserializeValue(Type type, string jsonValue)
+    {
+        if (type == typeof(string)) return jsonValue;
+        if (type == typeof(int)) return int.Parse(jsonValue);
+        if (type == typeof(long)) return long.Parse(jsonValue);
+        if (type == typeof(float)) return float.Parse(jsonValue);
+        if (type == typeof(double)) return double.Parse(jsonValue);
+        if (type == typeof(bool)) return bool.Parse(jsonValue);
+        if (type == typeof(RefID)) return RefID.Parse(jsonValue);
+
+        return JsonSerializer.Deserialize(jsonValue, type);
+    }
+
+    public Type? FindComponentType(string typeName)
+    {
+        var type = Type.GetType(typeName);
+        if (type != null && typeof(Component).IsAssignableFrom(type))
+        {
+            return type;
+        }
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            type = assembly.GetType(typeName);
+            if (type != null && typeof(Component).IsAssignableFrom(type))
+            {
+                return type;
+            }
+        }
+
+        return null;
+    }
+
+    public IReadOnlyList<Type> GetAllComponentTypes() => _componentTypesCache.Value;
+
+    private IReadOnlyList<Type> ScanComponentTypes()
+    {
+        _logger.LogInformation("Scanning component types...");
+        var componentType = typeof(Component);
+        var types = new List<Type>();
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            try
+            {
+                // Only scan FrooxEngine and related assemblies
+                var assemblyName = assembly.GetName().Name;
+                if (assemblyName == null ||
+                    (!assemblyName.StartsWith("FrooxEngine") &&
+                     !assemblyName.StartsWith("ProtoFlux") &&
+                     !assemblyName.StartsWith("Elements")))
+                {
+                    continue;
+                }
+
+                foreach (var type in assembly.GetTypes())
+                {
+                    if (type.IsClass && !type.IsAbstract && componentType.IsAssignableFrom(type))
+                    {
+                        types.Add(type);
+                    }
+                }
+            }
+            catch
+            {
+                // Skip assemblies that can't be scanned
+            }
+        }
+
+        var result = types.OrderBy(t => t.FullName).ToList();
+        _logger.LogInformation("Found {Count} component types", result.Count);
+        return result;
+    }
+}

--- a/Headless/GraphQL/Types/ComponentType.cs
+++ b/Headless/GraphQL/Types/ComponentType.cs
@@ -1,0 +1,65 @@
+using FrooxEngine;
+using HotChocolate;
+
+namespace Headless.GraphQL.Types;
+
+[ObjectType]
+public class ComponentType
+{
+    private readonly Component _component;
+
+    public ComponentType(Component component)
+    {
+        _component = component;
+    }
+
+    public string RefId => _component.ReferenceID.ToString();
+    public string TypeName => _component.GetType().Name;
+    public string TypeFullName => _component.GetType().FullName ?? _component.GetType().Name;
+    public bool Enabled => _component.Enabled;
+    public bool IsPersistent => _component.IsPersistent;
+
+    public SlotType Slot => new SlotType(_component.Slot);
+
+    public int SyncMemberCount => _component.SyncMemberCount;
+
+    [GraphQLName("syncMembers")]
+    public IEnumerable<ISyncMemberType> AllSyncMembers
+    {
+        get
+        {
+            for (int i = 0; i < _component.SyncMemberCount; i++)
+            {
+                var member = _component.GetSyncMember(i);
+                var name = _component.GetSyncMemberName(i);
+                yield return SyncMemberTypeFactory.Create(member, name, i);
+            }
+        }
+    }
+
+    [GraphQLName("syncMemberByName")]
+    public ISyncMemberType? GetSyncMember(string name)
+    {
+        for (int i = 0; i < _component.SyncMemberCount; i++)
+        {
+            var memberName = _component.GetSyncMemberName(i);
+            if (memberName == name)
+            {
+                return SyncMemberTypeFactory.Create(_component.GetSyncMember(i), memberName, i);
+            }
+        }
+        return null;
+    }
+
+    [GraphQLName("syncMemberByIndex")]
+    public ISyncMemberType? GetSyncMemberByIndex(int index)
+    {
+        if (index < 0 || index >= _component.SyncMemberCount)
+        {
+            return null;
+        }
+        var member = _component.GetSyncMember(index);
+        var name = _component.GetSyncMemberName(index);
+        return SyncMemberTypeFactory.Create(member, name, index);
+    }
+}

--- a/Headless/GraphQL/Types/Scalars/RefIdType.cs
+++ b/Headless/GraphQL/Types/Scalars/RefIdType.cs
@@ -1,0 +1,51 @@
+using Elements.Core;
+using HotChocolate.Language;
+
+namespace Headless.GraphQL.Types.Scalars;
+
+public class RefIdType : ScalarType<RefID, StringValueNode>
+{
+    public RefIdType() : base("RefID")
+    {
+        Description = "Represents a FrooxEngine RefID";
+    }
+
+    public override IValueNode ParseResult(object? resultValue)
+    {
+        return ParseValue(resultValue);
+    }
+
+    protected override RefID ParseLiteral(StringValueNode valueSyntax)
+    {
+        return RefID.Parse(valueSyntax.Value);
+    }
+
+    protected override StringValueNode ParseValue(RefID runtimeValue)
+    {
+        return new StringValueNode(runtimeValue.ToString());
+    }
+
+    public override bool TrySerialize(object? runtimeValue, out object? resultValue)
+    {
+        if (runtimeValue is RefID refId)
+        {
+            resultValue = refId.ToString();
+            return true;
+        }
+
+        resultValue = null;
+        return false;
+    }
+
+    public override bool TryDeserialize(object? resultValue, out object? runtimeValue)
+    {
+        if (resultValue is string str)
+        {
+            runtimeValue = RefID.Parse(str);
+            return true;
+        }
+
+        runtimeValue = null;
+        return false;
+    }
+}

--- a/Headless/GraphQL/Types/Scalars/VectorTypes.cs
+++ b/Headless/GraphQL/Types/Scalars/VectorTypes.cs
@@ -1,0 +1,72 @@
+using Elements.Core;
+using HotChocolate.Types;
+
+namespace Headless.GraphQL.Types.Scalars;
+
+[ObjectType]
+public class Float3Type
+{
+    public float X { get; }
+    public float Y { get; }
+    public float Z { get; }
+
+    public Float3Type(float3 value)
+    {
+        X = value.x;
+        Y = value.y;
+        Z = value.z;
+    }
+
+    public Float3Type(float x, float y, float z)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    [GraphQLIgnore]
+    public float3 ToFloat3() => new float3(X, Y, Z);
+}
+
+[ObjectType]
+public class FloatQType
+{
+    public float X { get; }
+    public float Y { get; }
+    public float Z { get; }
+    public float W { get; }
+
+    public FloatQType(floatQ value)
+    {
+        X = value.x;
+        Y = value.y;
+        Z = value.z;
+        W = value.w;
+    }
+
+    [GraphQLIgnore]
+    public floatQ ToFloatQ() => new floatQ(X, Y, Z, W);
+}
+
+[InputObjectType]
+public class Float3Input
+{
+    public float X { get; set; }
+    public float Y { get; set; }
+    public float Z { get; set; }
+
+    [GraphQLIgnore]
+    public float3 ToFloat3() => new float3(X, Y, Z);
+}
+
+[InputObjectType]
+public class FloatQInput
+{
+    public float X { get; set; }
+    public float Y { get; set; }
+    public float Z { get; set; }
+    public float W { get; set; }
+
+    [GraphQLIgnore]
+    public floatQ ToFloatQ() => new floatQ(X, Y, Z, W);
+}

--- a/Headless/GraphQL/Types/SlotType.cs
+++ b/Headless/GraphQL/Types/SlotType.cs
@@ -1,0 +1,87 @@
+using FrooxEngine;
+using Headless.GraphQL.Types.Scalars;
+using HotChocolate;
+
+namespace Headless.GraphQL.Types;
+
+[ObjectType]
+public class SlotType
+{
+    private readonly Slot _slot;
+
+    public SlotType(Slot slot)
+    {
+        _slot = slot;
+    }
+
+    public string RefId => _slot.ReferenceID.ToString();
+    public string Name => _slot.Name ?? "";
+    public bool Active => _slot.ActiveSelf;
+    public bool Persistent => _slot.IsPersistent;
+    public string? Tag => _slot.Tag;
+
+    // Transform - Local
+    public Float3Type Position => new Float3Type(_slot.LocalPosition);
+    public FloatQType Rotation => new FloatQType(_slot.LocalRotation);
+    public Float3Type Scale => new Float3Type(_slot.LocalScale);
+
+    // Transform - Global
+    public Float3Type GlobalPosition => new Float3Type(_slot.GlobalPosition);
+    public FloatQType GlobalRotation => new FloatQType(_slot.GlobalRotation);
+    public Float3Type GlobalScale => new Float3Type(_slot.GlobalScale);
+
+    // Hierarchy
+    public SlotType? Parent => _slot.Parent != null ? new SlotType(_slot.Parent) : null;
+    public IEnumerable<SlotType> Children => _slot.Children.Select(c => new SlotType(c));
+    public int ChildCount => _slot.ChildrenCount;
+
+    // Components
+    [GraphQLName("components")]
+    public IEnumerable<ComponentType> AllComponents => _slot.Components.Select(c => new ComponentType(c));
+    public int ComponentCount => _slot.ComponentCount;
+
+    // SyncMembers
+    [GraphQLName("syncMembers")]
+    public IEnumerable<ISyncMemberType> AllSyncMembers
+    {
+        get
+        {
+            for (int i = 0; i < _slot.SyncMemberCount; i++)
+            {
+                var member = _slot.GetSyncMember(i);
+                var name = _slot.GetSyncMemberName(i);
+                yield return SyncMemberTypeFactory.Create(member, name, i);
+            }
+        }
+    }
+
+    [GraphQLName("syncMemberByName")]
+    public ISyncMemberType? GetSyncMember(string name)
+    {
+        for (int i = 0; i < _slot.SyncMemberCount; i++)
+        {
+            var memberName = _slot.GetSyncMemberName(i);
+            if (memberName == name)
+            {
+                return SyncMemberTypeFactory.Create(_slot.GetSyncMember(i), memberName, i);
+            }
+        }
+        return null;
+    }
+
+    [GraphQLName("componentByType")]
+    public ComponentType? GetComponent(string typeName)
+    {
+        var component = _slot.Components.FirstOrDefault(c =>
+            c.GetType().Name == typeName || c.GetType().FullName == typeName);
+        return component != null ? new ComponentType(component) : null;
+    }
+
+    [GraphQLName("componentsByType")]
+    public IEnumerable<ComponentType> GetComponents(string typeName)
+    {
+        return _slot.Components
+            .Where(c => c.GetType().Name == typeName || c.GetType().FullName == typeName)
+            .Select(c => new ComponentType(c));
+    }
+}

--- a/Headless/GraphQL/Types/SyncMemberType.cs
+++ b/Headless/GraphQL/Types/SyncMemberType.cs
@@ -1,0 +1,236 @@
+using System.Text.Json;
+using Elements.Core;
+using FrooxEngine;
+using IField = FrooxEngine.IField;
+
+namespace Headless.GraphQL.Types;
+
+[InterfaceType]
+public interface ISyncMemberType
+{
+    string Name { get; }
+    int Index { get; }
+    string TypeName { get; }
+    bool IsLinked { get; }
+}
+
+[ObjectType]
+public class SyncFieldType : ISyncMemberType
+{
+    private readonly IField _field;
+    private readonly string _name;
+    private readonly int _index;
+
+    public SyncFieldType(IField field, string name, int index)
+    {
+        _field = field;
+        _name = name;
+        _index = index;
+    }
+
+    public string Name => _name;
+    public int Index => _index;
+    public string TypeName => _field.GetType().Name;
+    public bool IsLinked => ((ISyncMember)_field).IsLinked;
+
+    public string ValueType => _field.ValueType.Name;
+    public string ValueTypeFullName => _field.ValueType.FullName ?? _field.ValueType.Name;
+
+    public string? Value
+    {
+        get
+        {
+            try
+            {
+                var boxed = _field.BoxedValue;
+                if (boxed == null) return null;
+
+                // Handle primitive types directly
+                if (boxed is string s) return s;
+                if (boxed is bool b) return b.ToString().ToLowerInvariant();
+                if (boxed is int or long or float or double or decimal)
+                {
+                    return boxed.ToString();
+                }
+                if (boxed is RefID refId)
+                {
+                    return refId.ToString();
+                }
+
+                // For complex types, serialize to JSON
+                return JsonSerializer.Serialize(boxed);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    public string? ValueAsString => _field.BoxedValue?.ToString();
+
+    public float? ValueAsFloat
+    {
+        get
+        {
+            var boxed = _field.BoxedValue;
+            if (boxed is float f) return f;
+            if (boxed is double d) return (float)d;
+            if (boxed is int i) return i;
+            if (boxed is long l) return l;
+            return null;
+        }
+    }
+
+    public int? ValueAsInt
+    {
+        get
+        {
+            var boxed = _field.BoxedValue;
+            if (boxed is int i) return i;
+            if (boxed is long l) return (int)l;
+            if (boxed is float f) return (int)f;
+            if (boxed is double d) return (int)d;
+            return null;
+        }
+    }
+
+    public bool? ValueAsBool
+    {
+        get
+        {
+            if (_field.BoxedValue is bool b) return b;
+            return null;
+        }
+    }
+}
+
+[ObjectType]
+public class SyncRefType : ISyncMemberType
+{
+    private readonly ISyncRef _syncRef;
+    private readonly string _name;
+    private readonly int _index;
+
+    public SyncRefType(ISyncRef syncRef, string name, int index)
+    {
+        _syncRef = syncRef;
+        _name = name;
+        _index = index;
+    }
+
+    public string Name => _name;
+    public int Index => _index;
+    public string TypeName => _syncRef.GetType().Name;
+    public bool IsLinked => ((ISyncMember)_syncRef).IsLinked;
+
+    public string? TargetTypeName
+    {
+        get
+        {
+            var targetType = _syncRef.GetType();
+            if (targetType.IsGenericType)
+            {
+                var genericArgs = targetType.GetGenericArguments();
+                if (genericArgs.Length > 0)
+                {
+                    return genericArgs[0].Name;
+                }
+            }
+            return null;
+        }
+    }
+
+    public string? TargetRefId
+    {
+        get
+        {
+            try
+            {
+                var valueProperty = _syncRef.GetType().GetProperty("Value");
+                if (valueProperty?.GetValue(_syncRef) is RefID refId && refId != default)
+                {
+                    return refId.ToString();
+                }
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    public SlotType? TargetAsSlot
+    {
+        get
+        {
+            try
+            {
+                var targetProperty = _syncRef.GetType().GetProperty("Target");
+                if (targetProperty?.GetValue(_syncRef) is Slot slot)
+                {
+                    return new SlotType(slot);
+                }
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    public ComponentType? TargetAsComponent
+    {
+        get
+        {
+            try
+            {
+                var targetProperty = _syncRef.GetType().GetProperty("Target");
+                if (targetProperty?.GetValue(_syncRef) is Component component)
+                {
+                    return new ComponentType(component);
+                }
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}
+
+[ObjectType]
+public class GenericSyncMemberType : ISyncMemberType
+{
+    private readonly ISyncMember _member;
+    private readonly string _name;
+    private readonly int _index;
+
+    public GenericSyncMemberType(ISyncMember member, string name, int index)
+    {
+        _member = member;
+        _name = name;
+        _index = index;
+    }
+
+    public string Name => _name;
+    public int Index => _index;
+    public string TypeName => _member.GetType().Name;
+    public bool IsLinked => _member.IsLinked;
+}
+
+public static class SyncMemberTypeFactory
+{
+    public static ISyncMemberType Create(ISyncMember member, string name, int index)
+    {
+        return member switch
+        {
+            IField field => new SyncFieldType(field, name, index),
+            ISyncRef syncRef => new SyncRefType(syncRef, name, index),
+            _ => new GenericSyncMemberType(member, name, index)
+        };
+    }
+}

--- a/Headless/GraphQL/Types/WorldType.cs
+++ b/Headless/GraphQL/Types/WorldType.cs
@@ -34,7 +34,8 @@ public class WorldType
         string refId,
         [Service] FrooxEngineGraphQLService service)
     {
-        var parsedRefId = RefID.Parse(refId);
+        if (!service.TryParseRefId(refId, out var parsedRefId)) return null;
+
         var slot = service.FindSlotByRefId(_world, parsedRefId);
         return slot != null ? new SlotType(slot) : null;
     }

--- a/Headless/GraphQL/Types/WorldType.cs
+++ b/Headless/GraphQL/Types/WorldType.cs
@@ -1,0 +1,105 @@
+using Elements.Core;
+using FrooxEngine;
+using Headless.GraphQL.Services;
+
+namespace Headless.GraphQL.Types;
+
+[ObjectType]
+public class WorldType
+{
+    private readonly World _world;
+
+    public WorldType(World world)
+    {
+        _world = world;
+    }
+
+    public string SessionId => _world.SessionId;
+    public string Name => _world.Name ?? "";
+    public string? Description => _world.Description;
+    public int UserCount => _world.UserCount;
+    public int MaxUsers => _world.MaxUsers;
+    public string AccessLevel => _world.AccessLevel.ToString();
+
+    public SlotType RootSlot => new SlotType(_world.RootSlot);
+
+    public IEnumerable<WorldUserType> Users =>
+        _world.AllUsers.Select(u => new WorldUserType(u));
+
+    public WorldUserType? HostUser => _world.HostUser != null
+        ? new WorldUserType(_world.HostUser)
+        : null;
+
+    public SlotType? FindSlotByRefId(
+        string refId,
+        [Service] FrooxEngineGraphQLService service)
+    {
+        var parsedRefId = RefID.Parse(refId);
+        var slot = service.FindSlotByRefId(_world, parsedRefId);
+        return slot != null ? new SlotType(slot) : null;
+    }
+
+    public IEnumerable<SlotType> FindSlotByName(string name, bool searchChildren = true)
+    {
+        var slots = new List<Slot>();
+        if (searchChildren)
+        {
+            FindSlotsRecursive(_world.RootSlot, name, slots);
+        }
+        else
+        {
+            foreach (var child in _world.RootSlot.Children)
+            {
+                if (child.Name == name)
+                {
+                    slots.Add(child);
+                }
+            }
+        }
+        return slots.Select(s => new SlotType(s));
+    }
+
+    public SlotType? FindSlotByPath(string path)
+    {
+        var slot = _world.RootSlot.FindChild(s => s.Name == path);
+        return slot != null ? new SlotType(slot) : null;
+    }
+
+    private void FindSlotsRecursive(Slot parent, string name, List<Slot> results)
+    {
+        foreach (var child in parent.Children)
+        {
+            if (child.Name == name)
+            {
+                results.Add(child);
+            }
+            FindSlotsRecursive(child, name, results);
+        }
+    }
+}
+
+[ObjectType]
+public class WorldUserType
+{
+    private readonly User _user;
+
+    public WorldUserType(User user)
+    {
+        _user = user;
+    }
+
+    public string UserId => _user.UserID ?? "";
+    public string UserName => _user.UserName ?? "";
+    public string Role => _user.Role?.RoleName?.Value ?? "";
+    public bool IsPresent => _user.IsPresent;
+    public bool IsHost => _user.IsHost;
+
+    public SlotType? UserRootSlot
+    {
+        get
+        {
+            var rootSlot = _user.Root?.Slot;
+            return rootSlot != null ? new SlotType(rootSlot) : null;
+        }
+    }
+}

--- a/Headless/Headless.csproj
+++ b/Headless/Headless.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="15.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="10.0.0" />
   </ItemGroup>
 

--- a/Headless/Program.cs
+++ b/Headless/Program.cs
@@ -27,9 +27,14 @@ public class Program
         var appConfigInstance = appConfig.Get<ApplicationConfig>() ?? new ApplicationConfig();
         var graphqlConfig = appConfig.GetSection("GraphQL").Get<GraphQLConfig>() ?? new GraphQLConfig();
 
-        // Parse gRPC port from RpcHostUrl
-        var grpcUri = new Uri(appConfigInstance.RpcHostUrl);
-        var grpcPort = grpcUri.Port > 0 ? grpcUri.Port : 5014;
+        // Parse gRPC port from RpcHostUrl (default to 5014 if invalid or empty)
+        var grpcPort = 5014;
+        if (!string.IsNullOrEmpty(appConfigInstance.RpcHostUrl) &&
+            Uri.TryCreate(appConfigInstance.RpcHostUrl, UriKind.Absolute, out var grpcUri) &&
+            grpcUri.Port > 0)
+        {
+            grpcPort = grpcUri.Port;
+        }
 
         // Configure Kestrel with separate ports for gRPC (HTTP/2) and GraphQL (HTTP/1.1)
         builder.WebHost.ConfigureKestrel(options =>

--- a/Headless/Program.cs
+++ b/Headless/Program.cs
@@ -1,7 +1,14 @@
+using System.Net;
 using Elements.Core;
 using FrooxEngine;
 using Headless.Configuration;
+using Headless.GraphQL.Mutations;
+using Headless.GraphQL.Queries;
+using Headless.GraphQL.Services;
+using Headless.GraphQL.Types;
+using Headless.GraphQL.Types.Scalars;
 using Headless.Services;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace Headless;
 
@@ -15,6 +22,33 @@ public class Program
             .Build();
 
         builder.Logging.ClearProviders().AddConsole();
+
+        // Get configs early for Kestrel setup
+        var appConfigInstance = appConfig.Get<ApplicationConfig>() ?? new ApplicationConfig();
+        var graphqlConfig = appConfig.GetSection("GraphQL").Get<GraphQLConfig>() ?? new GraphQLConfig();
+
+        // Parse gRPC port from RpcHostUrl
+        var grpcUri = new Uri(appConfigInstance.RpcHostUrl);
+        var grpcPort = grpcUri.Port > 0 ? grpcUri.Port : 5014;
+
+        // Configure Kestrel with separate ports for gRPC (HTTP/2) and GraphQL (HTTP/1.1)
+        builder.WebHost.ConfigureKestrel(options =>
+        {
+            // gRPC endpoint - HTTP/2 only
+            options.Listen(IPAddress.IPv6Any, grpcPort, listenOptions =>
+            {
+                listenOptions.Protocols = HttpProtocols.Http2;
+            });
+
+            // GraphQL endpoint - HTTP/1.1 only (if enabled)
+            if (graphqlConfig.Enabled)
+            {
+                options.Listen(IPAddress.IPv6Any, graphqlConfig.Port, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http1;
+                });
+            }
+        });
 
         builder.Host.ConfigureServices((hostContext, services) =>
         {
@@ -37,21 +71,54 @@ public class Program
                 .AddSingleton<FrooxEngineRunnerService>()
                 .AddSingleton<IHostedService>(p => p.GetRequiredService<FrooxEngineRunnerService>())
                 .AddSingleton<IFrooxEngineRunnerService>(p => p.GetRequiredService<FrooxEngineRunnerService>());
+
+            // GraphQL
+            services.Configure<GraphQLConfig>(appConfig.GetSection("GraphQL"));
+            services.AddSingleton<FrooxEngineGraphQLService>();
+            services
+                .AddGraphQLServer()
+                .AddQueryType()
+                .AddMutationType()
+                // Queries
+                .AddTypeExtension<WorldQueries>()
+                // Mutations
+                .AddTypeExtension<SyncMemberMutations>()
+                .AddTypeExtension<SlotMutations>()
+                .AddTypeExtension<ComponentMutations>()
+                // Types
+                .AddType<WorldType>()
+                .AddType<SlotType>()
+                .AddType<ComponentType>()
+                .AddType<SyncFieldType>()
+                .AddType<SyncRefType>()
+                .AddType<GenericSyncMemberType>()
+                .AddType<Float3Type>()
+                .AddType<FloatQType>()
+                .AddType<RefIdType>();
         });
 
         var app = builder.Build();
 
         // Configure the HTTP request pipeline.
-        app.MapGrpcService<GrpcControllerService>();
-        app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
+        // gRPC endpoint (port-specific)
+        app.MapGrpcService<GrpcControllerService>().RequireHost($"*:{grpcPort}");
+        app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909")
+            .RequireHost($"*:{grpcPort}");
+
+        // GraphQL endpoint (port-specific, conditional)
+        if (graphqlConfig.Enabled)
+        {
+            app.MapGraphQL(graphqlConfig.Path).RequireHost($"*:{graphqlConfig.Port}");
+            app.MapGet("/", () => "GraphQL Playground is available at " + graphqlConfig.Path)
+                .RequireHost($"*:{graphqlConfig.Port}");
+        }
 
         var logger = app.Services.GetRequiredService<ILogger<Program>>();
         UniLog.OnLog += msg => FilterLogMsg(logger, msg);
         UniLog.OnWarning += msg => logger.LogWarning(msg);
         UniLog.OnError += msg => logger.LogError(msg);
 
-        var appConfigInstance = appConfig.Get<ApplicationConfig>() ?? new ApplicationConfig();
-        app.Run(appConfigInstance.RpcHostUrl);
+        app.Run();
     }
 
     private static void FilterLogMsg(ILogger logger, string message)

--- a/Headless/Services/FrooxEngineRunnerService.cs
+++ b/Headless/Services/FrooxEngineRunnerService.cs
@@ -139,8 +139,8 @@ public class FrooxEngineRunnerService : BackgroundService, IFrooxEngineRunnerSer
         var launchOptions = new LaunchOptions
         {
             OutputDevice = Renderite.Shared.HeadOutputDevice.Headless,
-            DataDirectory = Path.Combine(_appConfig.DataDirectoryPath, "Data"),
-            CacheDirectory = Path.Combine(_appConfig.DataDirectoryPath, "Cache"),
+            DataDirectory = System.IO.Path.Combine(_appConfig.DataDirectoryPath, "Data"),
+            CacheDirectory = System.IO.Path.Combine(_appConfig.DataDirectoryPath, "Cache"),
             LogsDirectory = null!,
             VerboseInit = true,
             NeverSaveSettings = true,

--- a/docs/graphql_usage.md
+++ b/docs/graphql_usage.md
@@ -1,0 +1,736 @@
+# FrooxEngine GraphQL API 利用ガイド
+
+このドキュメントは、FrooxEngine（Resonite）のWorld内の状態を調査・操作するためのGraphQL APIの使い方を説明します。
+
+## 基本概念
+
+### Resonite/FrooxEngineのデータ構造
+
+```
+World (ワールド/セッション)
+├── RootSlot (ルートスロット)
+│   ├── Slot (子スロット)
+│   │   ├── Component (コンポーネント)
+│   │   │   └── SyncMember (プロパティ)
+│   │   │       ├── SyncField (値型: 数値、文字列、bool等)
+│   │   │       └── SyncRef (参照型: 他のSlot/Componentへの参照)
+│   │   └── Slot (孫スロット)
+│   │       └── ...
+│   └── ...
+└── Users (ユーザー一覧)
+```
+
+**用語説明:**
+
+| 用語 | 説明 |
+|------|------|
+| **World** | 一つのセッション/ワールド。SessionIdで識別される |
+| **Slot** | 3D空間上のオブジェクト。位置・回転・スケールを持ち、階層構造を形成 |
+| **Component** | Slotにアタッチされる機能単位（MeshRenderer, Collider, ValueField等） |
+| **SyncMember** | Componentのプロパティ。SyncFieldとSyncRefの2種類がある |
+| **SyncField** | 値を保持するプロパティ（int, float, string, bool, float3等） |
+| **SyncRef** | 他のSlot/Componentへの参照を保持するプロパティ |
+| **RefID** | オブジェクトの一意識別子（例: `ID8A2B3C4D`） |
+
+## エンドポイント
+
+```
+http://localhost:5050/graphql
+```
+
+GraphQL Playgroundも同じURLでアクセス可能です。
+
+**注意:** GraphQLはgRPC（ポート5014）とは別ポートで動作します。
+
+## 設定
+
+環境変数で設定:
+```bash
+# GraphQLを有効化（デフォルト: true）
+GraphQL__Enabled=true
+
+# GraphQLのポート番号（デフォルト: 5050）
+GraphQL__Port=5050
+
+# GraphQLのパス（デフォルト: /graphql）
+GraphQL__Path=/graphql
+```
+
+## Query（読み取り操作）
+
+### 1. ワールド一覧の取得
+
+```graphql
+query {
+  worlds {
+    sessionId
+    name
+    userCount
+    maxUsers
+    accessLevel
+  }
+}
+```
+
+### 2. 特定ワールドの詳細取得
+
+```graphql
+query GetWorld($sessionId: String!) {
+  world(sessionId: $sessionId) {
+    sessionId
+    name
+    description
+    userCount
+    rootSlot {
+      refId
+      name
+    }
+    users {
+      userId
+      userName
+      isHost
+      isPresent
+    }
+  }
+}
+```
+
+### 3. Slot階層の探索
+
+**RootSlotから子を取得:**
+```graphql
+query ExploreSlots($sessionId: String!) {
+  world(sessionId: $sessionId) {
+    rootSlot {
+      name
+      children {
+        refId
+        name
+        active
+        childCount
+        componentCount
+      }
+    }
+  }
+}
+```
+
+**特定のSlotを深掘り:**
+```graphql
+query GetSlotDetails($sessionId: String!, $refId: String!) {
+  slot(sessionId: $sessionId, refId: $refId) {
+    refId
+    name
+    active
+    tag
+    position { x y z }
+    rotation { x y z w }
+    scale { x y z }
+    parent {
+      refId
+      name
+    }
+    children {
+      refId
+      name
+    }
+    components {
+      refId
+      typeName
+      enabled
+    }
+  }
+}
+```
+
+### 4. Slotを名前で検索
+
+```graphql
+query FindSlotsByName($sessionId: String!, $name: String!) {
+  world(sessionId: $sessionId) {
+    findSlotByName(name: $name, searchChildren: true) {
+      refId
+      name
+      parent {
+        name
+      }
+    }
+  }
+}
+```
+
+### 5. Componentのプロパティ取得
+
+**全プロパティを列挙:**
+```graphql
+query GetComponentProperties($sessionId: String!, $refId: String!) {
+  component(sessionId: $sessionId, refId: $refId) {
+    refId
+    typeName
+    typeFullName
+    enabled
+    syncMemberCount
+    syncMembers {
+      name
+      typeName
+      isLinked
+      ... on SyncFieldType {
+        valueType
+        value
+        valueAsString
+        valueAsFloat
+        valueAsInt
+        valueAsBool
+      }
+      ... on SyncRefType {
+        targetRefId
+        targetTypeName
+        targetAsSlot {
+          refId
+          name
+        }
+        targetAsComponent {
+          refId
+          typeName
+        }
+      }
+    }
+  }
+}
+```
+
+**特定のプロパティを取得:**
+```graphql
+query GetSpecificProperty($sessionId: String!, $refId: String!) {
+  component(sessionId: $sessionId, refId: $refId) {
+    syncMemberByName(name: "Value") {
+      name
+      ... on SyncFieldType {
+        valueType
+        value
+      }
+    }
+  }
+}
+```
+
+### 6. Slotから特定タイプのComponentを検索
+
+```graphql
+query FindComponents($sessionId: String!, $slotRefId: String!) {
+  slot(sessionId: $sessionId, refId: $slotRefId) {
+    componentByType(typeName: "ValueField`1") {
+      refId
+      typeName
+      syncMembers {
+        name
+        ... on SyncFieldType {
+          value
+        }
+      }
+    }
+  }
+}
+```
+
+**複数のComponentを取得:**
+```graphql
+query FindMultipleComponents($sessionId: String!, $slotRefId: String!) {
+  slot(sessionId: $sessionId, refId: $slotRefId) {
+    componentsByType(typeName: "Sync`1") {
+      refId
+      typeName
+    }
+  }
+}
+```
+
+### 7. アタッチ可能なComponentタイプ一覧
+
+```graphql
+query ListComponentTypes {
+  componentTypes(filter: null) {
+    name
+    fullName
+    category
+    isGeneric
+  }
+}
+```
+
+**フィルター付きで検索:**
+```graphql
+query SearchComponents {
+  componentTypes(filter: "Light") {
+    name
+    fullName
+    category
+  }
+}
+```
+
+**結果例:**
+```json
+{
+  "data": {
+    "componentTypes": [
+      { "name": "Light", "fullName": "FrooxEngine.Light", "category": "Core" },
+      { "name": "LightSource", "fullName": "FrooxEngine.LightSource", "category": "Core" }
+    ]
+  }
+}
+```
+
+`fullName` を `attachComponent` の `componentTypeName` に使用します。
+
+## Mutation（変更操作）
+
+### 1. Slotの操作
+
+**子Slotを追加:**
+```graphql
+mutation AddSlot($sessionId: String!, $parentRefId: String!, $name: String!) {
+  addChildSlot(sessionId: $sessionId, parentSlotRefId: $parentRefId, name: $name) {
+    refId
+    name
+  }
+}
+```
+
+**Slotを削除:**
+```graphql
+mutation DeleteSlot($sessionId: String!, $slotRefId: String!) {
+  deleteSlot(sessionId: $sessionId, slotRefId: $slotRefId, preserveChildren: false) {
+    success
+    deletedRefId
+    error
+  }
+}
+```
+
+**Slotの有効/無効を切り替え:**
+```graphql
+mutation ToggleSlot($sessionId: String!, $slotRefId: String!, $active: Boolean!) {
+  setSlotActive(sessionId: $sessionId, slotRefId: $slotRefId, active: $active) {
+    refId
+    active
+  }
+}
+```
+
+**Slotの名前を変更:**
+```graphql
+mutation RenameSlot($sessionId: String!, $slotRefId: String!, $name: String!) {
+  setSlotName(sessionId: $sessionId, slotRefId: $slotRefId, name: $name) {
+    refId
+    name
+  }
+}
+```
+
+**Slotの位置を変更:**
+```graphql
+mutation MoveSlot($sessionId: String!, $slotRefId: String!) {
+  setSlotPosition(
+    sessionId: $sessionId
+    slotRefId: $slotRefId
+    x: 1.0
+    y: 2.0
+    z: 3.0
+    global: false
+  ) {
+    refId
+    position { x y z }
+  }
+}
+```
+
+### 2. Componentの操作
+
+**Componentをアタッチ:**
+```graphql
+mutation AttachComponent($sessionId: String!, $slotRefId: String!, $typeName: String!) {
+  attachComponent(
+    sessionId: $sessionId
+    slotRefId: $slotRefId
+    componentTypeName: $typeName
+  ) {
+    refId
+    typeName
+    syncMembers {
+      name
+      typeName
+    }
+  }
+}
+```
+
+例えば `FrooxEngine.ValueField`1` や `FrooxEngine.MeshRenderer` などを指定。
+
+**Componentを削除:**
+```graphql
+mutation RemoveComponent($sessionId: String!, $componentRefId: String!) {
+  removeComponent(sessionId: $sessionId, componentRefId: $componentRefId) {
+    success
+    removedRefId
+    removedTypeName
+    error
+  }
+}
+```
+
+**Componentの有効/無効を切り替え:**
+```graphql
+mutation ToggleComponent($sessionId: String!, $componentRefId: String!, $enabled: Boolean!) {
+  setComponentEnabled(
+    sessionId: $sessionId
+    componentRefId: $componentRefId
+    enabled: $enabled
+  ) {
+    refId
+    enabled
+  }
+}
+```
+
+### 3. プロパティの変更
+
+**SyncField（値型）の変更:**
+```graphql
+mutation SetFieldValue($sessionId: String!, $componentRefId: String!) {
+  setSyncFieldValue(
+    sessionId: $sessionId
+    componentRefId: $componentRefId
+    memberName: "Value"
+    value: "42"
+  ) {
+    success
+    previousValue
+    newValue
+    error
+  }
+}
+```
+
+**値の形式:**
+- 数値: `"42"`, `"3.14"`
+- 文字列: `"hello"`
+- bool: `"true"`, `"false"`
+- float3: `{"x":1,"y":2,"z":3}` (JSON形式)
+
+**SyncRef（参照型）の変更:**
+```graphql
+mutation SetRefTarget($sessionId: String!, $componentRefId: String!) {
+  setSyncRefTarget(
+    sessionId: $sessionId
+    componentRefId: $componentRefId
+    memberName: "Target"
+    targetRefId: "ID12345678"
+  ) {
+    success
+    previousRefId
+    newRefId
+    error
+  }
+}
+```
+
+参照を解除する場合は `targetRefId: null` を指定。
+
+## よくあるユースケース
+
+### ユースケース1: ワールド内の全オブジェクトを探索
+
+```graphql
+# Step 1: ワールドのRootSlotを取得
+query {
+  world(sessionId: "S-xxx") {
+    rootSlot {
+      refId
+      children {
+        refId
+        name
+        childCount
+      }
+    }
+  }
+}
+
+# Step 2: 興味のあるSlotの子を再帰的に取得
+query {
+  slot(sessionId: "S-xxx", refId: "取得したRefId") {
+    children {
+      refId
+      name
+      childCount
+      componentCount
+    }
+  }
+}
+```
+
+### ユースケース2: 特定のComponentタイプを持つSlotを探す
+
+```graphql
+# まずSlotを取得し、componentsをチェック
+query {
+  slot(sessionId: "S-xxx", refId: "xxx") {
+    name
+    components {
+      typeName
+      refId
+    }
+    children {
+      name
+      refId
+      components {
+        typeName
+        refId
+      }
+    }
+  }
+}
+```
+
+### ユースケース3: オブジェクトの配置を変更
+
+```graphql
+# 位置を変更
+mutation {
+  setSlotPosition(
+    sessionId: "S-xxx"
+    slotRefId: "xxx"
+    x: 0
+    y: 1.5
+    z: 0
+    global: true
+  ) {
+    globalPosition { x y z }
+  }
+}
+
+# 回転を変更
+mutation {
+  setSlotRotation(
+    sessionId: "S-xxx"
+    slotRefId: "xxx"
+    x: 0
+    y: 0.707
+    z: 0
+    w: 0.707
+    global: false
+  ) {
+    rotation { x y z w }
+  }
+}
+
+# スケールを変更
+mutation {
+  setSlotScale(
+    sessionId: "S-xxx"
+    slotRefId: "xxx"
+    x: 2.0
+    y: 2.0
+    z: 2.0
+  ) {
+    scale { x y z }
+  }
+}
+```
+
+### ユースケース4: 新しいオブジェクトを作成
+
+```graphql
+# Step 1: 親Slotの下に新しいSlotを作成
+mutation {
+  addChildSlot(
+    sessionId: "S-xxx"
+    parentSlotRefId: "parentRefId"
+    name: "MyNewObject"
+  ) {
+    refId
+    name
+  }
+}
+
+# Step 2: 必要なComponentをアタッチ
+mutation {
+  attachComponent(
+    sessionId: "S-xxx"
+    slotRefId: "新しく作成したSlotのRefId"
+    componentTypeName: "FrooxEngine.MeshRenderer"
+  ) {
+    refId
+    typeName
+  }
+}
+
+# Step 3: Componentのプロパティを設定
+mutation {
+  setSyncFieldValue(
+    sessionId: "S-xxx"
+    componentRefId: "xxx"
+    memberName: "Enabled"
+    value: "true"
+  ) {
+    success
+  }
+}
+```
+
+### ユースケース5: 参照関係を辿る
+
+```graphql
+# SyncRefの参照先を取得
+query {
+  component(sessionId: "S-xxx", refId: "xxx") {
+    syncMembers {
+      name
+      ... on SyncRefType {
+        targetRefId
+        targetAsSlot {
+          refId
+          name
+          position { x y z }
+        }
+        targetAsComponent {
+          refId
+          typeName
+        }
+      }
+    }
+  }
+}
+```
+
+## 型情報
+
+### スカラー型
+
+| 型名 | 説明 | 例 |
+|------|------|-----|
+| `String` | 文字列 | `"hello"` |
+| `Int` | 整数 | `42` |
+| `Float` | 浮動小数点 | `3.14` |
+| `Boolean` | 真偽値 | `true`, `false` |
+
+### オブジェクト型
+
+#### SlotType
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `refId` | String! | RefID |
+| `name` | String! | Slot名 |
+| `active` | Boolean! | 有効/無効 |
+| `position` | Float3Type! | ローカル位置 |
+| `globalPosition` | Float3Type! | グローバル位置 |
+| `rotation` | FloatQType! | ローカル回転 |
+| `scale` | Float3Type! | ローカルスケール |
+| `parent` | SlotType | 親Slot |
+| `children` | [SlotType!]! | 子Slot一覧 |
+| `childCount` | Int! | 子Slot数 |
+| `components` | [ComponentType!]! | 全Component一覧 |
+| `componentCount` | Int! | Component数 |
+| `componentByType(typeName)` | ComponentType | 型名で検索（最初の1件） |
+| `componentsByType(typeName)` | [ComponentType!]! | 型名で検索（全件） |
+| `syncMembers` | [ISyncMemberType!]! | 全SyncMember一覧 |
+| `syncMemberByName(name)` | ISyncMemberType | 名前でSyncMember検索 |
+
+#### ComponentType
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `refId` | String! | RefID |
+| `typeName` | String! | 型名（短縮形） |
+| `typeFullName` | String! | 完全修飾型名 |
+| `enabled` | Boolean! | 有効/無効 |
+| `slot` | SlotType! | 所属Slot |
+| `syncMemberCount` | Int! | SyncMember数 |
+| `syncMembers` | [ISyncMemberType!]! | 全SyncMember一覧 |
+| `syncMemberByName(name)` | ISyncMemberType | 名前でSyncMember検索 |
+| `syncMemberByIndex(index)` | ISyncMemberType | インデックスでSyncMember検索 |
+
+#### ComponentTypeInfo
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `name` | String! | 型名（短縮形） |
+| `fullName` | String! | 完全修飾型名 |
+| `category` | String | カテゴリ（Core, UIX, ProtoFlux, Avatar, IK, LogiX） |
+| `isGeneric` | Boolean! | ジェネリック型かどうか |
+| `genericDefinition` | String | ジェネリック定義名（ジェネリック型の場合のみ） |
+
+#### Float3Type（位置・スケール）
+```graphql
+{
+  x: Float!
+  y: Float!
+  z: Float!
+}
+```
+
+#### FloatQType（回転・クォータニオン）
+```graphql
+{
+  x: Float!
+  y: Float!
+  z: Float!
+  w: Float!
+}
+```
+
+### SyncMemberの型判別
+
+```graphql
+syncMembers {
+  __typename  # "SyncFieldType" or "SyncRefType" or "GenericSyncMemberType"
+  name
+  index
+  typeName
+  isLinked
+  ... on SyncFieldType {
+    # SyncFieldの場合のみ
+    valueType
+    value
+    valueAsString
+    valueAsFloat
+    valueAsInt
+    valueAsBool
+  }
+  ... on SyncRefType {
+    # SyncRefの場合のみ
+    targetRefId
+    targetTypeName
+    targetAsSlot { ... }
+    targetAsComponent { ... }
+  }
+}
+```
+
+## 注意事項
+
+1. **RefID形式**: RefIDは `ID` で始まる16進数文字列（例: `ID8A2B3C4D`）
+2. **SessionId形式**: SessionIdは `S-` で始まる文字列
+3. **スレッド安全**: 全ての操作はワールドスレッド上で実行されるため安全
+4. **存在確認**: Slot/Componentが存在しない場合は `null` が返る
+5. **値の形式**: `setSyncFieldValue`の`value`は文字列で渡す。複合型はJSON形式
+6. **型名**: `attachComponent`の型名は完全修飾名（例: `FrooxEngine.MeshRenderer`）
+
+## トラブルシューティング
+
+### "Session not found" エラー
+- `sessionId`が正しいか確認
+- ワールドが起動しているか確認
+- `worlds`クエリで利用可能なセッション一覧を取得
+
+### "Slot/Component not found" エラー
+- `refId`が正しいか確認
+- 対象オブジェクトが削除されていないか確認
+- 正しい`sessionId`を使用しているか確認
+
+### プロパティの変更が反映されない
+- `memberName`が正確か確認（大文字小文字を区別）
+- `value`の形式が正しいか確認
+- Mutationの`success`フィールドを確認
+
+### "Component type not found" エラー
+- 型名が完全修飾名か確認（例: `FrooxEngine.MeshRenderer`）
+- ジェネリック型の場合は `` `1 `` などの修飾子を含める

--- a/docs/test_rpcs.md
+++ b/docs/test_rpcs.md
@@ -1,0 +1,15 @@
+ワールド開始
+```
+grpcurl -plaintext -proto proto/headless/v1/headless.proto -d '{
+  "parameters": {
+    "name": "test",
+    "access_level": "ACCESS_LEVEL_PRIVATE",
+    "load_world_preset_name": "Grid"
+  }
+}' localhost:5014 headless.v1.HeadlessControlService/StartWorld
+```
+
+セッション一覧
+```
+grpcurl -plaintext -proto proto/headless/v1/headless.proto localhost:5014 headless.v1.HeadlessControlService/ListSessions
+```

--- a/scripts/download-resonite.sh
+++ b/scripts/download-resonite.sh
@@ -42,11 +42,19 @@ download_with_depot_downloader() {
   TEMP_DIR=$(mktemp -d)
   trap 'rm -rf "$TEMP_DIR"' RETURN
 
-  if [ "$(arch)" == "aarch64" ]; then
-    wget https://github.com/SteamRE/DepotDownloader/releases/latest/download/DepotDownloader-linux-arm64.zip -O "$TEMP_DIR/DepotDownloader.zip"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    DEPOT_OS="macos"
   else
-    wget https://github.com/SteamRE/DepotDownloader/releases/latest/download/DepotDownloader-linux-x64.zip -O "$TEMP_DIR/DepotDownloader.zip"
+    DEPOT_OS="linux"
   fi
+
+  if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
+    DEPOT_ARCH="arm64"
+  else
+    DEPOT_ARCH="x64"
+  fi
+
+  wget "https://github.com/SteamRE/DepotDownloader/releases/latest/download/DepotDownloader-${DEPOT_OS}-${DEPOT_ARCH}.zip" -O "$TEMP_DIR/DepotDownloader.zip"
   unzip "$TEMP_DIR/DepotDownloader.zip" -d "$TEMP_DIR"
   chmod +x "$TEMP_DIR/DepotDownloader"
 


### PR DESCRIPTION
## Summary

- FrooxEngineの内部状態（World Slot tree、コンポーネントプロパティ）をGraphQLでquery/mutationできるAPIエンドポイントを追加
- gRPC（ポート5014）とは別ポート（デフォルト5050）で動作
- ISyncMember/IFieldの汎用インターフェースを活用し、Resoniteアップデートに自動追従できる軽量実装

## Features

### Query
- `worlds` - 全ワールド一覧
- `world(sessionId)` - 特定ワールド詳細
- `slot(sessionId, refId)` - Slot取得
- `component(sessionId, refId)` - Component取得
- `componentTypes(filter)` - アタッチ可能なComponent型一覧（キャッシュ付き）

### Mutation
- Slot操作: `addChildSlot`, `deleteSlot`, `setSlotName`, `setSlotActive`, `setSlotPosition`
- Component操作: `attachComponent`, `removeComponent`
- SyncMember操作: `setSyncFieldValue`, `setSyncRefTarget`

### Types
- `SlotType` - 位置/回転/スケール、階層、Component一覧
- `ComponentType` - 型情報、SyncMember一覧
- `SyncFieldType` / `SyncRefType` - 値/参照の取得・設定

## Configuration

```bash
GraphQL__Enabled=true   # デフォルト: true
GraphQL__Port=5050      # デフォルト: 5050
GraphQL__Path=/graphql  # デフォルト: /graphql
```

## Test plan

- [x] 全Query動作確認（worlds, world, slot, component, componentTypes）
- [x] 全Mutation動作確認（slot/component/syncMember操作）
- [x] componentTypesのキャッシュ動作確認
- [x] gRPCエンドポイント（5014）との共存確認