### PR TITLE
fix: Hardware.Info.Coreアセンブリへの参照を追加

### DIFF
--- a/Headless/Headless.csproj
+++ b/Headless/Headless.csproj
@@ -64,6 +64,9 @@
     <Reference Include="Hardware.Info">
       <HintPath>$(ResonitePath)/Hardware.Info.dll</HintPath>
     </Reference>
+    <Reference Include="Hardware.Info.Core">
+      <HintPath>$(ResonitePath)/Hardware.Info.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AspNetCore.SignalR.Client.Core">
       <HintPath>$(ResonitePath)/Microsoft.AspNetCore.SignalR.Client.Core.dll</HintPath>
     </Reference>


### PR DESCRIPTION
## Summary
- ResoniteアップデートでHardware.Infoパッケージが分割され、`HardwareInfoBase`が新アセンブリ`Hardware.Info.Core`へ移動したためビルドが失敗していた
- `Headless.csproj`に`Hardware.Info.Core.dll`への参照を追加して修正
- 参考: https://github.com/hantabaru1014/baru-reso-headless-container/actions/runs/24752173957

## Test plan
- [x] ローカルで`make build.docker`が成功することを確認
- [ ] CIのビルド/テストがパスすること