### PR TITLE
feat: セッションワールドのバイナリダウンロードRPCを追加

### DIFF
--- a/Headless/Models/RunningSession.cs
+++ b/Headless/Models/RunningSession.cs
@@ -1,4 +1,6 @@
+using Elements.Core;
 using FrooxEngine;
+using Headless.Rpc;
 using SkyFrost.Base;
 
 namespace Headless.Models;
@@ -199,6 +201,55 @@ public class RunningSession
             return true;
         }
         return false;
+    }
+
+    public async Task ExportWorldBinaryAsync(
+        WorldBinaryFormat format,
+        System.IO.Stream destination,
+        bool includeVariants,
+        int? brotliQuality,
+        CancellationToken ct = default)
+    {
+        if (!Instance.IsAllowedToSaveWorld())
+        {
+            throw new InvalidOperationException("World is not allowed to be saved");
+        }
+
+        var graph = await Instance.Coroutines.StartTask(async () =>
+        {
+            await default(NextUpdate);
+            // resonitepackage は SDK の PackageImporter が record.RecordType == "object" のみ受け付けるため
+            // (FrooxEngine.PackageImporter.ImportPackage の "Currently only object packages are supported")、
+            // RootSlot を Object として保存する。7zbson / brson は世界として開けるので World.SaveWorld() を使う。
+            return format == WorldBinaryFormat.Resonitepackage
+                ? Instance.RootSlot.SaveObject(DependencyHandling.CollectAssets)
+                : Instance.SaveWorld();
+        });
+        if (graph is null)
+        {
+            throw new InvalidOperationException("Failed to capture world snapshot");
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        switch (format)
+        {
+            case WorldBinaryFormat._7Zbson:
+                DataTreeConverter.To7zBSON(graph.Root, destination);
+                break;
+            case WorldBinaryFormat.Brson:
+                DataTreeConverter.ToBRSON(graph.Root, destination, brotliQuality ?? 9);
+                break;
+            case WorldBinaryFormat.Resonitepackage:
+                // PackageExportable.Export と同じ作り方: フレッシュな object レコード。
+                var worldName = !string.IsNullOrWhiteSpace(Instance.RawName) ? Instance.RawName : "World";
+                var ownerId = Instance.Engine.Cloud.CurrentUserID ?? Instance.Engine.LocalDB.MachineID;
+                var packageRecord = RecordHelper.CreateForObject<Record>(worldName, ownerId, null);
+                await PackageCreator.BuildPackage(Instance.Engine, packageRecord, graph, destination, includeVariants);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(format), format, "Unsupported world binary format");
+        }
     }
 
     public async Task<FrooxEngine.Store.Record?> SaveWorldCopy(string? ownerId)

--- a/Headless/Protos/Headless.cs
+++ b/Headless/Protos/Headless.cs
@@ -123,229 +123,241 @@ namespace Headless.Rpc {
             "eXBlIlsKClNhdmVBc1R5cGUSHAoYU0FWRV9BU19UWVBFX1VOU1BFQ0lGSUVE",
             "EAASGAoUU0FWRV9BU19UWVBFX1NBVkVfQVMQARIVChFTQVZFX0FTX1RZUEVf",
             "Q09QWRACIkYKGlNhdmVBc1Nlc3Npb25Xb3JsZFJlc3BvbnNlEigKEHNhdmVk",
-            "X3JlY29yZF91cmwYASABKAlSDnNhdmVkUmVjb3JkVXJsInQKEUludml0ZVVz",
-            "ZXJSZXF1ZXN0Eh0KCnNlc3Npb25faWQYASABKAlSCXNlc3Npb25JZBIZCgd1",
-            "c2VyX2lkGAIgASgJSABSBnVzZXJJZBIdCgl1c2VyX25hbWUYAyABKAlIAFII",
-            "dXNlck5hbWVCBgoEdXNlciIUChJJbnZpdGVVc2VyUmVzcG9uc2UiUAoWQWxs",
-            "b3dVc2VyVG9Kb2luUmVxdWVzdBIdCgpzZXNzaW9uX2lkGAEgASgJUglzZXNz",
-            "aW9uSWQSFwoHdXNlcl9pZBgCIAEoCVIGdXNlcklkIhkKF0FsbG93VXNlclRv",
-            "Sm9pblJlc3BvbnNlIowBChVVcGRhdGVVc2VyUm9sZVJlcXVlc3QSHQoKc2Vz",
-            "c2lvbl9pZBgBIAEoCVIJc2Vzc2lvbklkEhkKB3VzZXJfaWQYAiABKAlIAFIG",
-            "dXNlcklkEh0KCXVzZXJfbmFtZRgDIAEoCUgAUgh1c2VyTmFtZRISCgRyb2xl",
-            "GAQgASgJUgRyb2xlQgYKBHVzZXIiLAoWVXBkYXRlVXNlclJvbGVSZXNwb25z",
-            "ZRISCgRyb2xlGAEgASgJUgRyb2xlIuEMCh5VcGRhdGVTZXNzaW9uUGFyYW1l",
-            "dGVyc1JlcXVlc3QSHQoKc2Vzc2lvbl9pZBgBIAEoCVIJc2Vzc2lvbklkEhcK",
-            "BG5hbWUYAiABKAlIAFIEbmFtZYgBARIlCgtkZXNjcmlwdGlvbhgDIAEoCUgB",
-            "UgtkZXNjcmlwdGlvbogBARIgCgltYXhfdXNlcnMYBCABKAVIAlIIbWF4VXNl",
-            "cnOIAQESQAoMYWNjZXNzX2xldmVsGAUgASgOMhguaGVhZGxlc3MudjEuQWNj",
-            "ZXNzTGV2ZWxIA1ILYWNjZXNzTGV2ZWyIAQESLwoRYXdheV9raWNrX21pbnV0",
-            "ZXMYBiABKAJIBFIPYXdheUtpY2tNaW51dGVziAEBEkYKHWlkbGVfcmVzdGFy",
-            "dF9pbnRlcnZhbF9zZWNvbmRzGAcgASgFSAVSGmlkbGVSZXN0YXJ0SW50ZXJ2",
-            "YWxTZWNvbmRziAEBEiUKDHNhdmVfb25fZXhpdBgIIAEoCEgGUgpzYXZlT25F",
-            "eGl0iAEBEkAKGmF1dG9fc2F2ZV9pbnRlcnZhbF9zZWNvbmRzGAkgASgFSAdS",
-            "F2F1dG9TYXZlSW50ZXJ2YWxTZWNvbmRziAEBEiIKCmF1dG9fc2xlZXAYCiAB",
-            "KAhICFIJYXV0b1NsZWVwiAEBEjwKGGhpZGVfZnJvbV9wdWJsaWNfbGlzdGlu",
-            "ZxgLIAEoCEgJUhVoaWRlRnJvbVB1YmxpY0xpc3RpbmeIAQESHwoLdXBkYXRl",
-            "X3RhZ3MYDCABKAhSCnVwZGF0ZVRhZ3MSEgoEdGFncxgNIAMoCVIEdGFncxI8",
-            "Chh1c2VfY3VzdG9tX2pvaW5fdmVyaWZpZXIYDiABKAhIClIVdXNlQ3VzdG9t",
-            "Sm9pblZlcmlmaWVyiAEBEiwKD21vYmlsZV9mcmllbmRseRgPIAEoCEgLUg5t",
-            "b2JpbGVGcmllbmRseYgBARJhCh9vdmVycmlkZV9jb3JyZXNwb25kaW5nX3dv",
-            "cmxkX2lkGBAgASgLMhUuaGVhZGxlc3MudjEuUmVjb3JkSWRIDFIcb3ZlcnJp",
-            "ZGVDb3JyZXNwb25kaW5nV29ybGRJZIgBARIzChNyb2xlX2Nsb3VkX3Zhcmlh",
-            "YmxlGBEgASgJSA1SEXJvbGVDbG91ZFZhcmlhYmxliAEBEj4KGWFsbG93X3Vz",
-            "ZXJfY2xvdWRfdmFyaWFibGUYEiABKAlIDlIWYWxsb3dVc2VyQ2xvdWRWYXJp",
-            "YWJsZYgBARI8ChhkZW55X3VzZXJfY2xvdWRfdmFyaWFibGUYEyABKAlID1IV",
-            "ZGVueVVzZXJDbG91ZFZhcmlhYmxliAEBEk0KIXJlcXVpcmVkX3VzZXJfam9p",
-            "bl9jbG91ZF92YXJpYWJsZRgUIAEoCUgQUh1yZXF1aXJlZFVzZXJKb2luQ2xv",
-            "dWRWYXJpYWJsZYgBARJlCi5yZXF1aXJlZF91c2VyX2pvaW5fY2xvdWRfdmFy",
-            "aWFibGVfZGVueV9tZXNzYWdlGBUgASgJSBFSKHJlcXVpcmVkVXNlckpvaW5D",
-            "bG91ZFZhcmlhYmxlRGVueU1lc3NhZ2WIAQFCBwoFX25hbWVCDgoMX2Rlc2Ny",
-            "aXB0aW9uQgwKCl9tYXhfdXNlcnNCDwoNX2FjY2Vzc19sZXZlbEIUChJfYXdh",
-            "eV9raWNrX21pbnV0ZXNCIAoeX2lkbGVfcmVzdGFydF9pbnRlcnZhbF9zZWNv",
-            "bmRzQg8KDV9zYXZlX29uX2V4aXRCHQobX2F1dG9fc2F2ZV9pbnRlcnZhbF9z",
-            "ZWNvbmRzQg0KC19hdXRvX3NsZWVwQhsKGV9oaWRlX2Zyb21fcHVibGljX2xp",
-            "c3RpbmdCGwoZX3VzZV9jdXN0b21fam9pbl92ZXJpZmllckISChBfbW9iaWxl",
-            "X2ZyaWVuZGx5QiIKIF9vdmVycmlkZV9jb3JyZXNwb25kaW5nX3dvcmxkX2lk",
-            "QhYKFF9yb2xlX2Nsb3VkX3ZhcmlhYmxlQhwKGl9hbGxvd191c2VyX2Nsb3Vk",
-            "X3ZhcmlhYmxlQhsKGV9kZW55X3VzZXJfY2xvdWRfdmFyaWFibGVCJAoiX3Jl",
-            "cXVpcmVkX3VzZXJfam9pbl9jbG91ZF92YXJpYWJsZUIxCi9fcmVxdWlyZWRf",
-            "dXNlcl9qb2luX2Nsb3VkX3ZhcmlhYmxlX2RlbnlfbWVzc2FnZSIhCh9VcGRh",
-            "dGVTZXNzaW9uUGFyYW1ldGVyc1Jlc3BvbnNlIjoKGUxpc3RVc2Vyc0luU2Vz",
-            "c2lvblJlcXVlc3QSHQoKc2Vzc2lvbl9pZBgBIAEoCVIJc2Vzc2lvbklkIk4K",
-            "Gkxpc3RVc2Vyc0luU2Vzc2lvblJlc3BvbnNlEjAKBXVzZXJzGAEgAygLMhou",
-            "aGVhZGxlc3MudjEuVXNlckluU2Vzc2lvblIFdXNlcnMiZgoNVXNlckluU2Vz",
-            "c2lvbhIOCgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIEbmFtZRISCgRy",
-            "b2xlGAMgASgJUgRyb2xlEh0KCmlzX3ByZXNlbnQYBCABKAhSCWlzUHJlc2Vu",
-            "dCJJCghVc2VySW5mbxIOCgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIE",
-            "bmFtZRIZCghpY29uX3VybBgDIAEoCVIHaWNvblVybCLuBwoHU2Vzc2lvbhIO",
-            "CgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIEbmFtZRIgCgtkZXNjcmlw",
-            "dGlvbhgDIAEoCVILZGVzY3JpcHRpb24SOwoMYWNjZXNzX2xldmVsGAQgASgO",
-            "MhguaGVhZGxlc3MudjEuQWNjZXNzTGV2ZWxSC2FjY2Vzc0xldmVsEh8KC3Vz",
-            "ZXJzX2NvdW50GAcgASgFUgp1c2Vyc0NvdW50EhsKCW1heF91c2VycxgIIAEo",
-            "BVIIbWF4VXNlcnMSKAoNdGh1bWJuYWlsX3VybBgFIAEoCUgAUgx0aHVtYm5h",
-            "aWxVcmyIAQESUgoSc3RhcnR1cF9wYXJhbWV0ZXJzGAYgASgLMiMuaGVhZGxl",
-            "c3MudjEuV29ybGRTdGFydHVwUGFyYW1ldGVyc1IRc3RhcnR1cFBhcmFtZXRl",
-            "cnMSHwoLc2Vzc2lvbl91cmwYCSABKAlSCnNlc3Npb25VcmwSKgoPdGltZV9y",
-            "dW5uaW5nX21zGAogASgFQgIYAVINdGltZVJ1bm5pbmdNcxIqChFhd2F5X2tp",
-            "Y2tfbWludXRlcxgLIAEoAlIPYXdheUtpY2tNaW51dGVzEkEKHWlkbGVfcmVz",
-            "dGFydF9pbnRlcnZhbF9zZWNvbmRzGAwgASgFUhppZGxlUmVzdGFydEludGVy",
-            "dmFsU2Vjb25kcxIgCgxzYXZlX29uX2V4aXQYDSABKAhSCnNhdmVPbkV4aXQS",
-            "OwoaYXV0b19zYXZlX2ludGVydmFsX3NlY29uZHMYDiABKAVSF2F1dG9TYXZl",
-            "SW50ZXJ2YWxTZWNvbmRzEh0KCmF1dG9fc2xlZXAYDyABKAhSCWF1dG9TbGVl",
-            "cBI3ChhoaWRlX2Zyb21fcHVibGljX2xpc3RpbmcYECABKAhSFWhpZGVGcm9t",
-            "UHVibGljTGlzdGluZxISCgR0YWdzGBEgAygJUgR0YWdzEkMKDWxhc3Rfc2F2",
-            "ZWRfYXQYEiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wSAFSC2xh",
-            "c3RTYXZlZEF0iAEBEhkKCGNhbl9zYXZlGBMgASgIUgdjYW5TYXZlEhsKCXdv",
-            "cmxkX3VybBgUIAEoCVIId29ybGRVcmwSOQoKc3RhcnRlZF9hdBgVIAEoCzIa",
-            "Lmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSCXN0YXJ0ZWRBdBIhCgxjb25u",
-            "ZWN0X3VyaXMYFiADKAlSC2Nvbm5lY3RVcmlzEh4KC2Nhbl9zYXZlX2FzGBcg",
-            "ASgIUgljYW5TYXZlQXNCEAoOX3RodW1ibmFpbF91cmxCEAoOX2xhc3Rfc2F2",
-            "ZWRfYXQiQgoPRGVmYXVsdFVzZXJSb2xlEhIKBHJvbGUYASABKAlSBHJvbGUS",
-            "GwoJdXNlcl9uYW1lGAIgASgJUgh1c2VyTmFtZSL6DwoWV29ybGRTdGFydHVw",
-            "UGFyYW1ldGVycxIXCgRuYW1lGAEgASgJSAFSBG5hbWWIAQESLwoRY3VzdG9t",
-            "X3Nlc3Npb25faWQYAiABKAlIAlIPY3VzdG9tU2Vzc2lvbklkiAEBEiUKC2Rl",
-            "c2NyaXB0aW9uGAMgASgJSANSC2Rlc2NyaXB0aW9uiAEBEhIKBHRhZ3MYCiAD",
-            "KAlSBHRhZ3MSIAoJbWF4X3VzZXJzGAQgASgFSARSCG1heFVzZXJziAEBEjsK",
-            "DGFjY2Vzc19sZXZlbBgFIAEoDjIYLmhlYWRsZXNzLnYxLkFjY2Vzc0xldmVs",
-            "UgthY2Nlc3NMZXZlbBImCg5sb2FkX3dvcmxkX3VybBgGIAEoCUgAUgxsb2Fk",
-            "V29ybGRVcmwSNQoWbG9hZF93b3JsZF9wcmVzZXRfbmFtZRgHIAEoCUgAUhNs",
-            "b2FkV29ybGRQcmVzZXROYW1lEjIKFWF1dG9faW52aXRlX3VzZXJuYW1lcxgI",
-            "IAMoCVITYXV0b0ludml0ZVVzZXJuYW1lcxI3ChhoaWRlX2Zyb21fcHVibGlj",
-            "X2xpc3RpbmcYCSABKAhSFWhpZGVGcm9tUHVibGljTGlzdGluZxJKChJkZWZh",
-            "dWx0X3VzZXJfcm9sZXMYCyADKAsyHC5oZWFkbGVzcy52MS5EZWZhdWx0VXNl",
-            "clJvbGVSEGRlZmF1bHRVc2VyUm9sZXMSKgoRYXdheV9raWNrX21pbnV0ZXMY",
-            "DCABKAJSD2F3YXlLaWNrTWludXRlcxJBCh1pZGxlX3Jlc3RhcnRfaW50ZXJ2",
-            "YWxfc2Vjb25kcxgNIAEoBVIaaWRsZVJlc3RhcnRJbnRlcnZhbFNlY29uZHMS",
-            "IAoMc2F2ZV9vbl9leGl0GA4gASgIUgpzYXZlT25FeGl0EjsKGmF1dG9fc2F2",
-            "ZV9pbnRlcnZhbF9zZWNvbmRzGA8gASgFUhdhdXRvU2F2ZUludGVydmFsU2Vj",
-            "b25kcxIdCgphdXRvX3NsZWVwGBAgASgIUglhdXRvU2xlZXASRwogaW52aXRl",
-            "X3JlcXVlc3RfaGFuZGxlcl91c2VybmFtZXMYESADKAlSHWludml0ZVJlcXVl",
-            "c3RIYW5kbGVyVXNlcm5hbWVzEh0KCmZvcmNlX3BvcnQYEiABKA1SCWZvcmNl",
-            "UG9ydBIsChJwYXJlbnRfc2Vzc2lvbl9pZHMYEyADKAlSEHBhcmVudFNlc3Np",
-            "b25JZHMSIQoMYXV0b19yZWNvdmVyGBQgASgIUgthdXRvUmVjb3ZlchJFCh9m",
-            "b3JjZWRfcmVzdGFydF9pbnRlcnZhbF9zZWNvbmRzGBUgASgFUhxmb3JjZWRS",
-            "ZXN0YXJ0SW50ZXJ2YWxTZWNvbmRzEjcKGHVzZV9jdXN0b21fam9pbl92ZXJp",
-            "ZmllchgWIAEoCFIVdXNlQ3VzdG9tSm9pblZlcmlmaWVyEicKD21vYmlsZV9m",
-            "cmllbmRseRgXIAEoCFIObW9iaWxlRnJpZW5kbHkSYQofb3ZlcnJpZGVfY29y",
-            "cmVzcG9uZGluZ193b3JsZF9pZBgYIAEoCzIVLmhlYWRsZXNzLnYxLlJlY29y",
-            "ZElkSAVSHG92ZXJyaWRlQ29ycmVzcG9uZGluZ1dvcmxkSWSIAQESLgoTa2Vl",
-            "cF9vcmlnaW5hbF9yb2xlcxgZIAEoCFIRa2VlcE9yaWdpbmFsUm9sZXMSMwoT",
-            "cm9sZV9jbG91ZF92YXJpYWJsZRgaIAEoCUgGUhFyb2xlQ2xvdWRWYXJpYWJs",
-            "ZYgBARI+ChlhbGxvd191c2VyX2Nsb3VkX3ZhcmlhYmxlGBsgASgJSAdSFmFs",
-            "bG93VXNlckNsb3VkVmFyaWFibGWIAQESPAoYZGVueV91c2VyX2Nsb3VkX3Zh",
-            "cmlhYmxlGBwgASgJSAhSFWRlbnlVc2VyQ2xvdWRWYXJpYWJsZYgBARJNCiFy",
-            "ZXF1aXJlZF91c2VyX2pvaW5fY2xvdWRfdmFyaWFibGUYHSABKAlICVIdcmVx",
-            "dWlyZWRVc2VySm9pbkNsb3VkVmFyaWFibGWIAQESZQoucmVxdWlyZWRfdXNl",
-            "cl9qb2luX2Nsb3VkX3ZhcmlhYmxlX2RlbnlfbWVzc2FnZRgeIAEoCUgKUihy",
-            "ZXF1aXJlZFVzZXJKb2luQ2xvdWRWYXJpYWJsZURlbnlNZXNzYWdliAEBEjMK",
-            "E2F1dG9faW52aXRlX21lc3NhZ2UYHyABKAlIC1IRYXV0b0ludml0ZU1lc3Nh",
-            "Z2WIAQESMQoVam9pbl9hbGxvd2VkX3VzZXJfaWRzGCAgAygJUhJqb2luQWxs",
-            "b3dlZFVzZXJJZHNCDAoKbG9hZF93b3JsZEIHCgVfbmFtZUIUChJfY3VzdG9t",
-            "X3Nlc3Npb25faWRCDgoMX2Rlc2NyaXB0aW9uQgwKCl9tYXhfdXNlcnNCIgog",
-            "X292ZXJyaWRlX2NvcnJlc3BvbmRpbmdfd29ybGRfaWRCFgoUX3JvbGVfY2xv",
-            "dWRfdmFyaWFibGVCHAoaX2FsbG93X3VzZXJfY2xvdWRfdmFyaWFibGVCGwoZ",
-            "X2RlbnlfdXNlcl9jbG91ZF92YXJpYWJsZUIkCiJfcmVxdWlyZWRfdXNlcl9q",
-            "b2luX2Nsb3VkX3ZhcmlhYmxlQjEKL19yZXF1aXJlZF91c2VyX2pvaW5fY2xv",
-            "dWRfdmFyaWFibGVfZGVueV9tZXNzYWdlQhYKFF9hdXRvX2ludml0ZV9tZXNz",
-            "YWdlIpkCChJDb250YWN0Q2hhdE1lc3NhZ2USDgoCaWQYASABKAlSAmlkEjcK",
-            "BHR5cGUYAiABKA4yIy5oZWFkbGVzcy52MS5Db250YWN0Q2hhdE1lc3NhZ2VU",
-            "eXBlUgR0eXBlEhgKB2NvbnRlbnQYAyABKAlSB2NvbnRlbnQSNwoJc2VuZF90",
-            "aW1lGAQgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIIc2VuZFRp",
-            "bWUSPAoJcmVhZF90aW1lGAUgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVz",
-            "dGFtcEgAUghyZWFkVGltZYgBARIbCglzZW5kZXJfaWQYBiABKAlSCHNlbmRl",
-            "cklkQgwKCl9yZWFkX3RpbWUipgIKEkFsbG93ZWRBY2Nlc3NFbnRyeRISCgRo",
-            "b3N0GAEgASgJUgRob3N0EhQKBXBvcnRzGAIgAygFUgVwb3J0cxJNCgxhY2Nl",
-            "c3NfdHlwZXMYAyADKA4yKi5oZWFkbGVzcy52MS5BbGxvd2VkQWNjZXNzRW50",
-            "cnkuQWNjZXNzVHlwZVILYWNjZXNzVHlwZXMilgEKCkFjY2Vzc1R5cGUSGwoX",
-            "QUNDRVNTX1RZUEVfVU5TUEVDSUZJRUQQABIUChBBQ0NFU1NfVFlQRV9IVFRQ",
-            "EAESGQoVQUNDRVNTX1RZUEVfV0VCU09DS0VUEAISHQoZQUNDRVNTX1RZUEVf",
-            "T1NDX1JFQ0VJVklORxADEhsKF0FDQ0VTU19UWVBFX09TQ19TRU5ESU5HEAQi",
-            "6QMKDVN0YXJ0dXBDb25maWcSJAoLdW5pdmVyc2VfaWQYASABKAlIAFIKdW5p",
-            "dmVyc2VJZIgBARIgCgl0aWNrX3JhdGUYAiABKAJIAVIIdGlja1JhdGWIAQES",
-            "SAoebWF4X2NvbmN1cnJlbnRfYXNzZXRfdHJhbnNmZXJzGAMgASgFSAJSG21h",
-            "eENvbmN1cnJlbnRBc3NldFRyYW5zZmVyc4gBARIwChF1c2VybmFtZV9vdmVy",
-            "cmlkZRgEIAEoCUgDUhB1c2VybmFtZU92ZXJyaWRliAEBEkYKDHN0YXJ0X3dv",
-            "cmxkcxgFIAMoCzIjLmhlYWRsZXNzLnYxLldvcmxkU3RhcnR1cFBhcmFtZXRl",
-            "cnNSC3N0YXJ0V29ybGRzEksKEWFsbG93ZWRfdXJsX2hvc3RzGAYgAygLMh8u",
-            "aGVhZGxlc3MudjEuQWxsb3dlZEFjY2Vzc0VudHJ5Ug9hbGxvd2VkVXJsSG9z",
-            "dHMSKAoQYXV0b19zcGF3bl9pdGVtcxgHIAMoCVIOYXV0b1NwYXduSXRlbXNC",
-            "DgoMX3VuaXZlcnNlX2lkQgwKCl90aWNrX3JhdGVCIQofX21heF9jb25jdXJy",
-            "ZW50X2Fzc2V0X3RyYW5zZmVyc0IUChJfdXNlcm5hbWVfb3ZlcnJpZGUiNQoI",
-            "UmVjb3JkSWQSDgoCaWQYASABKAlSAmlkEhkKCG93bmVyX2lkGAIgASgJUgdv",
-            "d25lcklkKtIBCgtBY2Nlc3NMZXZlbBIcChhBQ0NFU1NfTEVWRUxfVU5TUEVD",
-            "SUZJRUQQABIYChRBQ0NFU1NfTEVWRUxfUFJJVkFURRABEhQKEEFDQ0VTU19M",
-            "RVZFTF9MQU4QAhIZChVBQ0NFU1NfTEVWRUxfQ09OVEFDVFMQAxIeChpBQ0NF",
-            "U1NfTEVWRUxfQ09OVEFDVFNfUExVUxAEEiEKHUFDQ0VTU19MRVZFTF9SRUdJ",
-            "U1RFUkVEX1VTRVJTEAUSFwoTQUNDRVNTX0xFVkVMX0FOWU9ORRAGKuABChZD",
-            "b250YWN0Q2hhdE1lc3NhZ2VUeXBlEikKJUNPTlRBQ1RfQ0hBVF9NRVNTQUdF",
-            "X1RZUEVfVU5TUEVDSUZJRUQQABIiCh5DT05UQUNUX0NIQVRfTUVTU0FHRV9U",
-            "WVBFX1RFWFQQARIkCiBDT05UQUNUX0NIQVRfTUVTU0FHRV9UWVBFX09CSkVD",
-            "VBACEiMKH0NPTlRBQ1RfQ0hBVF9NRVNTQUdFX1RZUEVfU09VTkQQAxIsCihD",
-            "T05UQUNUX0NIQVRfTUVTU0FHRV9UWVBFX1NFU1NJT05fSU5WSVRFEAQy9hQK",
-            "FkhlYWRsZXNzQ29udHJvbFNlcnZpY2USRwoIR2V0QWJvdXQSHC5oZWFkbGVz",
-            "cy52MS5HZXRBYm91dFJlcXVlc3QaHS5oZWFkbGVzcy52MS5HZXRBYm91dFJl",
-            "c3BvbnNlEkoKCUdldFN0YXR1cxIdLmhlYWRsZXNzLnYxLkdldFN0YXR1c1Jl",
-            "cXVlc3QaHi5oZWFkbGVzcy52MS5HZXRTdGF0dXNSZXNwb25zZRJHCghTaHV0",
-            "ZG93bhIcLmhlYWRsZXNzLnYxLlNodXRkb3duUmVxdWVzdBodLmhlYWRsZXNz",
-            "LnYxLlNodXRkb3duUmVzcG9uc2USUwoMTGlzdFNlc3Npb25zEiAuaGVhZGxl",
-            "c3MudjEuTGlzdFNlc3Npb25zUmVxdWVzdBohLmhlYWRsZXNzLnYxLkxpc3RT",
-            "ZXNzaW9uc1Jlc3BvbnNlEk0KCkdldFNlc3Npb24SHi5oZWFkbGVzcy52MS5H",
-            "ZXRTZXNzaW9uUmVxdWVzdBofLmhlYWRsZXNzLnYxLkdldFNlc3Npb25SZXNw",
-            "b25zZRJNCgpTdGFydFdvcmxkEh4uaGVhZGxlc3MudjEuU3RhcnRXb3JsZFJl",
-            "cXVlc3QaHy5oZWFkbGVzcy52MS5TdGFydFdvcmxkUmVzcG9uc2USUAoLU3Rv",
-            "cFNlc3Npb24SHy5oZWFkbGVzcy52MS5TdG9wU2Vzc2lvblJlcXVlc3QaIC5o",
-            "ZWFkbGVzcy52MS5TdG9wU2Vzc2lvblJlc3BvbnNlEl8KEFNhdmVTZXNzaW9u",
-            "V29ybGQSJC5oZWFkbGVzcy52MS5TYXZlU2Vzc2lvbldvcmxkUmVxdWVzdBol",
-            "LmhlYWRsZXNzLnYxLlNhdmVTZXNzaW9uV29ybGRSZXNwb25zZRJlChJTYXZl",
-            "QXNTZXNzaW9uV29ybGQSJi5oZWFkbGVzcy52MS5TYXZlQXNTZXNzaW9uV29y",
-            "bGRSZXF1ZXN0GicuaGVhZGxlc3MudjEuU2F2ZUFzU2Vzc2lvbldvcmxkUmVz",
-            "cG9uc2USTQoKSW52aXRlVXNlchIeLmhlYWRsZXNzLnYxLkludml0ZVVzZXJS",
-            "ZXF1ZXN0Gh8uaGVhZGxlc3MudjEuSW52aXRlVXNlclJlc3BvbnNlElwKD0Fs",
-            "bG93VXNlclRvSm9pbhIjLmhlYWRsZXNzLnYxLkFsbG93VXNlclRvSm9pblJl",
-            "cXVlc3QaJC5oZWFkbGVzcy52MS5BbGxvd1VzZXJUb0pvaW5SZXNwb25zZRJZ",
-            "Cg5VcGRhdGVVc2VyUm9sZRIiLmhlYWRsZXNzLnYxLlVwZGF0ZVVzZXJSb2xl",
-            "UmVxdWVzdBojLmhlYWRsZXNzLnYxLlVwZGF0ZVVzZXJSb2xlUmVzcG9uc2US",
-            "dAoXVXBkYXRlU2Vzc2lvblBhcmFtZXRlcnMSKy5oZWFkbGVzcy52MS5VcGRh",
-            "dGVTZXNzaW9uUGFyYW1ldGVyc1JlcXVlc3QaLC5oZWFkbGVzcy52MS5VcGRh",
-            "dGVTZXNzaW9uUGFyYW1ldGVyc1Jlc3BvbnNlEmUKEkxpc3RVc2Vyc0luU2Vz",
-            "c2lvbhImLmhlYWRsZXNzLnYxLkxpc3RVc2Vyc0luU2Vzc2lvblJlcXVlc3Qa",
-            "Jy5oZWFkbGVzcy52MS5MaXN0VXNlcnNJblNlc3Npb25SZXNwb25zZRJHCghL",
-            "aWNrVXNlchIcLmhlYWRsZXNzLnYxLktpY2tVc2VyUmVxdWVzdBodLmhlYWRs",
-            "ZXNzLnYxLktpY2tVc2VyUmVzcG9uc2USRAoHQmFuVXNlchIbLmhlYWRsZXNz",
-            "LnYxLkJhblVzZXJSZXF1ZXN0GhwuaGVhZGxlc3MudjEuQmFuVXNlclJlc3Bv",
-            "bnNlElwKD0dldEhvc3RTZXR0aW5ncxIjLmhlYWRsZXNzLnYxLkdldEhvc3RT",
-            "ZXR0aW5nc1JlcXVlc3QaJC5oZWFkbGVzcy52MS5HZXRIb3N0U2V0dGluZ3NS",
-            "ZXNwb25zZRJlChJVcGRhdGVIb3N0U2V0dGluZ3MSJi5oZWFkbGVzcy52MS5V",
-            "cGRhdGVIb3N0U2V0dGluZ3NSZXF1ZXN0GicuaGVhZGxlc3MudjEuVXBkYXRl",
-            "SG9zdFNldHRpbmdzUmVzcG9uc2USXAoPQWxsb3dIb3N0QWNjZXNzEiMuaGVh",
-            "ZGxlc3MudjEuQWxsb3dIb3N0QWNjZXNzUmVxdWVzdBokLmhlYWRsZXNzLnYx",
-            "LkFsbG93SG9zdEFjY2Vzc1Jlc3BvbnNlElkKDkRlbnlIb3N0QWNjZXNzEiIu",
-            "aGVhZGxlc3MudjEuRGVueUhvc3RBY2Nlc3NSZXF1ZXN0GiMuaGVhZGxlc3Mu",
-            "djEuRGVueUhvc3RBY2Nlc3NSZXNwb25zZRJ6ChlHZXRTdGFydHVwQ29uZmln",
-            "VG9SZXN0b3JlEi0uaGVhZGxlc3MudjEuR2V0U3RhcnR1cENvbmZpZ1RvUmVz",
-            "dG9yZVJlcXVlc3QaLi5oZWFkbGVzcy52MS5HZXRTdGFydHVwQ29uZmlnVG9S",
-            "ZXN0b3JlUmVzcG9uc2USWQoOR2V0QWNjb3VudEluZm8SIi5oZWFkbGVzcy52",
-            "MS5HZXRBY2NvdW50SW5mb1JlcXVlc3QaIy5oZWFkbGVzcy52MS5HZXRBY2Nv",
-            "dW50SW5mb1Jlc3BvbnNlElkKDkZldGNoV29ybGRJbmZvEiIuaGVhZGxlc3Mu",
-            "djEuRmV0Y2hXb3JsZEluZm9SZXF1ZXN0GiMuaGVhZGxlc3MudjEuRmV0Y2hX",
-            "b3JsZEluZm9SZXNwb25zZRJZCg5TZWFyY2hVc2VySW5mbxIiLmhlYWRsZXNz",
-            "LnYxLlNlYXJjaFVzZXJJbmZvUmVxdWVzdBojLmhlYWRsZXNzLnYxLlNlYXJj",
-            "aFVzZXJJbmZvUmVzcG9uc2USYgoRR2V0RnJpZW5kUmVxdWVzdHMSJS5oZWFk",
-            "bGVzcy52MS5HZXRGcmllbmRSZXF1ZXN0c1JlcXVlc3QaJi5oZWFkbGVzcy52",
-            "MS5HZXRGcmllbmRSZXF1ZXN0c1Jlc3BvbnNlEmsKFEFjY2VwdEZyaWVuZFJl",
-            "cXVlc3RzEiguaGVhZGxlc3MudjEuQWNjZXB0RnJpZW5kUmVxdWVzdHNSZXF1",
-            "ZXN0GikuaGVhZGxlc3MudjEuQWNjZXB0RnJpZW5kUmVxdWVzdHNSZXNwb25z",
-            "ZRJTCgxMaXN0Q29udGFjdHMSIC5oZWFkbGVzcy52MS5MaXN0Q29udGFjdHNS",
-            "ZXF1ZXN0GiEuaGVhZGxlc3MudjEuTGlzdENvbnRhY3RzUmVzcG9uc2USZQoS",
-            "R2V0Q29udGFjdE1lc3NhZ2VzEiYuaGVhZGxlc3MudjEuR2V0Q29udGFjdE1l",
-            "c3NhZ2VzUmVxdWVzdBonLmhlYWRsZXNzLnYxLkdldENvbnRhY3RNZXNzYWdl",
-            "c1Jlc3BvbnNlEmUKElNlbmRDb250YWN0TWVzc2FnZRImLmhlYWRsZXNzLnYx",
-            "LlNlbmRDb250YWN0TWVzc2FnZVJlcXVlc3QaJy5oZWFkbGVzcy52MS5TZW5k",
-            "Q29udGFjdE1lc3NhZ2VSZXNwb25zZUIPqgIMSGVhZGxlc3MuUnBjYgZwcm90",
-            "bzM="));
+            "X3JlY29yZF91cmwYASABKAlSDnNhdmVkUmVjb3JkVXJsIvgBChtEb3dubG9h",
+            "ZFNlc3Npb25Xb3JsZFJlcXVlc3QSHQoKc2Vzc2lvbl9pZBgBIAEoCVIJc2Vz",
+            "c2lvbklkEjYKBmZvcm1hdBgCIAEoDjIeLmhlYWRsZXNzLnYxLldvcmxkQmlu",
+            "YXJ5Rm9ybWF0UgZmb3JtYXQSLgoQaW5jbHVkZV92YXJpYW50cxgDIAEoCEgA",
+            "Ug9pbmNsdWRlVmFyaWFudHOIAQESKgoOYnJvdGxpX3F1YWxpdHkYBCABKAVI",
+            "AVINYnJvdGxpUXVhbGl0eYgBAUITChFfaW5jbHVkZV92YXJpYW50c0IRCg9f",
+            "YnJvdGxpX3F1YWxpdHkiNAocRG93bmxvYWRTZXNzaW9uV29ybGRSZXNwb25z",
+            "ZRIUCgVjaHVuaxgBIAEoDFIFY2h1bmsidAoRSW52aXRlVXNlclJlcXVlc3QS",
+            "HQoKc2Vzc2lvbl9pZBgBIAEoCVIJc2Vzc2lvbklkEhkKB3VzZXJfaWQYAiAB",
+            "KAlIAFIGdXNlcklkEh0KCXVzZXJfbmFtZRgDIAEoCUgAUgh1c2VyTmFtZUIG",
+            "CgR1c2VyIhQKEkludml0ZVVzZXJSZXNwb25zZSJQChZBbGxvd1VzZXJUb0pv",
+            "aW5SZXF1ZXN0Eh0KCnNlc3Npb25faWQYASABKAlSCXNlc3Npb25JZBIXCgd1",
+            "c2VyX2lkGAIgASgJUgZ1c2VySWQiGQoXQWxsb3dVc2VyVG9Kb2luUmVzcG9u",
+            "c2UijAEKFVVwZGF0ZVVzZXJSb2xlUmVxdWVzdBIdCgpzZXNzaW9uX2lkGAEg",
+            "ASgJUglzZXNzaW9uSWQSGQoHdXNlcl9pZBgCIAEoCUgAUgZ1c2VySWQSHQoJ",
+            "dXNlcl9uYW1lGAMgASgJSABSCHVzZXJOYW1lEhIKBHJvbGUYBCABKAlSBHJv",
+            "bGVCBgoEdXNlciIsChZVcGRhdGVVc2VyUm9sZVJlc3BvbnNlEhIKBHJvbGUY",
+            "ASABKAlSBHJvbGUi4QwKHlVwZGF0ZVNlc3Npb25QYXJhbWV0ZXJzUmVxdWVz",
+            "dBIdCgpzZXNzaW9uX2lkGAEgASgJUglzZXNzaW9uSWQSFwoEbmFtZRgCIAEo",
+            "CUgAUgRuYW1liAEBEiUKC2Rlc2NyaXB0aW9uGAMgASgJSAFSC2Rlc2NyaXB0",
+            "aW9uiAEBEiAKCW1heF91c2VycxgEIAEoBUgCUghtYXhVc2Vyc4gBARJACgxh",
+            "Y2Nlc3NfbGV2ZWwYBSABKA4yGC5oZWFkbGVzcy52MS5BY2Nlc3NMZXZlbEgD",
+            "UgthY2Nlc3NMZXZlbIgBARIvChFhd2F5X2tpY2tfbWludXRlcxgGIAEoAkgE",
+            "Ug9hd2F5S2lja01pbnV0ZXOIAQESRgodaWRsZV9yZXN0YXJ0X2ludGVydmFs",
+            "X3NlY29uZHMYByABKAVIBVIaaWRsZVJlc3RhcnRJbnRlcnZhbFNlY29uZHOI",
+            "AQESJQoMc2F2ZV9vbl9leGl0GAggASgISAZSCnNhdmVPbkV4aXSIAQESQAoa",
+            "YXV0b19zYXZlX2ludGVydmFsX3NlY29uZHMYCSABKAVIB1IXYXV0b1NhdmVJ",
+            "bnRlcnZhbFNlY29uZHOIAQESIgoKYXV0b19zbGVlcBgKIAEoCEgIUglhdXRv",
+            "U2xlZXCIAQESPAoYaGlkZV9mcm9tX3B1YmxpY19saXN0aW5nGAsgASgISAlS",
+            "FWhpZGVGcm9tUHVibGljTGlzdGluZ4gBARIfCgt1cGRhdGVfdGFncxgMIAEo",
+            "CFIKdXBkYXRlVGFncxISCgR0YWdzGA0gAygJUgR0YWdzEjwKGHVzZV9jdXN0",
+            "b21fam9pbl92ZXJpZmllchgOIAEoCEgKUhV1c2VDdXN0b21Kb2luVmVyaWZp",
+            "ZXKIAQESLAoPbW9iaWxlX2ZyaWVuZGx5GA8gASgISAtSDm1vYmlsZUZyaWVu",
+            "ZGx5iAEBEmEKH292ZXJyaWRlX2NvcnJlc3BvbmRpbmdfd29ybGRfaWQYECAB",
+            "KAsyFS5oZWFkbGVzcy52MS5SZWNvcmRJZEgMUhxvdmVycmlkZUNvcnJlc3Bv",
+            "bmRpbmdXb3JsZElkiAEBEjMKE3JvbGVfY2xvdWRfdmFyaWFibGUYESABKAlI",
+            "DVIRcm9sZUNsb3VkVmFyaWFibGWIAQESPgoZYWxsb3dfdXNlcl9jbG91ZF92",
+            "YXJpYWJsZRgSIAEoCUgOUhZhbGxvd1VzZXJDbG91ZFZhcmlhYmxliAEBEjwK",
+            "GGRlbnlfdXNlcl9jbG91ZF92YXJpYWJsZRgTIAEoCUgPUhVkZW55VXNlckNs",
+            "b3VkVmFyaWFibGWIAQESTQohcmVxdWlyZWRfdXNlcl9qb2luX2Nsb3VkX3Zh",
+            "cmlhYmxlGBQgASgJSBBSHXJlcXVpcmVkVXNlckpvaW5DbG91ZFZhcmlhYmxl",
+            "iAEBEmUKLnJlcXVpcmVkX3VzZXJfam9pbl9jbG91ZF92YXJpYWJsZV9kZW55",
+            "X21lc3NhZ2UYFSABKAlIEVIocmVxdWlyZWRVc2VySm9pbkNsb3VkVmFyaWFi",
+            "bGVEZW55TWVzc2FnZYgBAUIHCgVfbmFtZUIOCgxfZGVzY3JpcHRpb25CDAoK",
+            "X21heF91c2Vyc0IPCg1fYWNjZXNzX2xldmVsQhQKEl9hd2F5X2tpY2tfbWlu",
+            "dXRlc0IgCh5faWRsZV9yZXN0YXJ0X2ludGVydmFsX3NlY29uZHNCDwoNX3Nh",
+            "dmVfb25fZXhpdEIdChtfYXV0b19zYXZlX2ludGVydmFsX3NlY29uZHNCDQoL",
+            "X2F1dG9fc2xlZXBCGwoZX2hpZGVfZnJvbV9wdWJsaWNfbGlzdGluZ0IbChlf",
+            "dXNlX2N1c3RvbV9qb2luX3ZlcmlmaWVyQhIKEF9tb2JpbGVfZnJpZW5kbHlC",
+            "IgogX292ZXJyaWRlX2NvcnJlc3BvbmRpbmdfd29ybGRfaWRCFgoUX3JvbGVf",
+            "Y2xvdWRfdmFyaWFibGVCHAoaX2FsbG93X3VzZXJfY2xvdWRfdmFyaWFibGVC",
+            "GwoZX2RlbnlfdXNlcl9jbG91ZF92YXJpYWJsZUIkCiJfcmVxdWlyZWRfdXNl",
+            "cl9qb2luX2Nsb3VkX3ZhcmlhYmxlQjEKL19yZXF1aXJlZF91c2VyX2pvaW5f",
+            "Y2xvdWRfdmFyaWFibGVfZGVueV9tZXNzYWdlIiEKH1VwZGF0ZVNlc3Npb25Q",
+            "YXJhbWV0ZXJzUmVzcG9uc2UiOgoZTGlzdFVzZXJzSW5TZXNzaW9uUmVxdWVz",
+            "dBIdCgpzZXNzaW9uX2lkGAEgASgJUglzZXNzaW9uSWQiTgoaTGlzdFVzZXJz",
+            "SW5TZXNzaW9uUmVzcG9uc2USMAoFdXNlcnMYASADKAsyGi5oZWFkbGVzcy52",
+            "MS5Vc2VySW5TZXNzaW9uUgV1c2VycyJmCg1Vc2VySW5TZXNzaW9uEg4KAmlk",
+            "GAEgASgJUgJpZBISCgRuYW1lGAIgASgJUgRuYW1lEhIKBHJvbGUYAyABKAlS",
+            "BHJvbGUSHQoKaXNfcHJlc2VudBgEIAEoCFIJaXNQcmVzZW50IkkKCFVzZXJJ",
+            "bmZvEg4KAmlkGAEgASgJUgJpZBISCgRuYW1lGAIgASgJUgRuYW1lEhkKCGlj",
+            "b25fdXJsGAMgASgJUgdpY29uVXJsIu4HCgdTZXNzaW9uEg4KAmlkGAEgASgJ",
+            "UgJpZBISCgRuYW1lGAIgASgJUgRuYW1lEiAKC2Rlc2NyaXB0aW9uGAMgASgJ",
+            "UgtkZXNjcmlwdGlvbhI7CgxhY2Nlc3NfbGV2ZWwYBCABKA4yGC5oZWFkbGVz",
+            "cy52MS5BY2Nlc3NMZXZlbFILYWNjZXNzTGV2ZWwSHwoLdXNlcnNfY291bnQY",
+            "ByABKAVSCnVzZXJzQ291bnQSGwoJbWF4X3VzZXJzGAggASgFUghtYXhVc2Vy",
+            "cxIoCg10aHVtYm5haWxfdXJsGAUgASgJSABSDHRodW1ibmFpbFVybIgBARJS",
+            "ChJzdGFydHVwX3BhcmFtZXRlcnMYBiABKAsyIy5oZWFkbGVzcy52MS5Xb3Js",
+            "ZFN0YXJ0dXBQYXJhbWV0ZXJzUhFzdGFydHVwUGFyYW1ldGVycxIfCgtzZXNz",
+            "aW9uX3VybBgJIAEoCVIKc2Vzc2lvblVybBIqCg90aW1lX3J1bm5pbmdfbXMY",
+            "CiABKAVCAhgBUg10aW1lUnVubmluZ01zEioKEWF3YXlfa2lja19taW51dGVz",
+            "GAsgASgCUg9hd2F5S2lja01pbnV0ZXMSQQodaWRsZV9yZXN0YXJ0X2ludGVy",
+            "dmFsX3NlY29uZHMYDCABKAVSGmlkbGVSZXN0YXJ0SW50ZXJ2YWxTZWNvbmRz",
+            "EiAKDHNhdmVfb25fZXhpdBgNIAEoCFIKc2F2ZU9uRXhpdBI7ChphdXRvX3Nh",
+            "dmVfaW50ZXJ2YWxfc2Vjb25kcxgOIAEoBVIXYXV0b1NhdmVJbnRlcnZhbFNl",
+            "Y29uZHMSHQoKYXV0b19zbGVlcBgPIAEoCFIJYXV0b1NsZWVwEjcKGGhpZGVf",
+            "ZnJvbV9wdWJsaWNfbGlzdGluZxgQIAEoCFIVaGlkZUZyb21QdWJsaWNMaXN0",
+            "aW5nEhIKBHRhZ3MYESADKAlSBHRhZ3MSQwoNbGFzdF9zYXZlZF9hdBgSIAEo",
+            "CzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIAVILbGFzdFNhdmVkQXSI",
+            "AQESGQoIY2FuX3NhdmUYEyABKAhSB2NhblNhdmUSGwoJd29ybGRfdXJsGBQg",
+            "ASgJUgh3b3JsZFVybBI5CgpzdGFydGVkX2F0GBUgASgLMhouZ29vZ2xlLnBy",
+            "b3RvYnVmLlRpbWVzdGFtcFIJc3RhcnRlZEF0EiEKDGNvbm5lY3RfdXJpcxgW",
+            "IAMoCVILY29ubmVjdFVyaXMSHgoLY2FuX3NhdmVfYXMYFyABKAhSCWNhblNh",
+            "dmVBc0IQCg5fdGh1bWJuYWlsX3VybEIQCg5fbGFzdF9zYXZlZF9hdCJCCg9E",
+            "ZWZhdWx0VXNlclJvbGUSEgoEcm9sZRgBIAEoCVIEcm9sZRIbCgl1c2VyX25h",
+            "bWUYAiABKAlSCHVzZXJOYW1lIvoPChZXb3JsZFN0YXJ0dXBQYXJhbWV0ZXJz",
+            "EhcKBG5hbWUYASABKAlIAVIEbmFtZYgBARIvChFjdXN0b21fc2Vzc2lvbl9p",
+            "ZBgCIAEoCUgCUg9jdXN0b21TZXNzaW9uSWSIAQESJQoLZGVzY3JpcHRpb24Y",
+            "AyABKAlIA1ILZGVzY3JpcHRpb26IAQESEgoEdGFncxgKIAMoCVIEdGFncxIg",
+            "CgltYXhfdXNlcnMYBCABKAVIBFIIbWF4VXNlcnOIAQESOwoMYWNjZXNzX2xl",
+            "dmVsGAUgASgOMhguaGVhZGxlc3MudjEuQWNjZXNzTGV2ZWxSC2FjY2Vzc0xl",
+            "dmVsEiYKDmxvYWRfd29ybGRfdXJsGAYgASgJSABSDGxvYWRXb3JsZFVybBI1",
+            "ChZsb2FkX3dvcmxkX3ByZXNldF9uYW1lGAcgASgJSABSE2xvYWRXb3JsZFBy",
+            "ZXNldE5hbWUSMgoVYXV0b19pbnZpdGVfdXNlcm5hbWVzGAggAygJUhNhdXRv",
+            "SW52aXRlVXNlcm5hbWVzEjcKGGhpZGVfZnJvbV9wdWJsaWNfbGlzdGluZxgJ",
+            "IAEoCFIVaGlkZUZyb21QdWJsaWNMaXN0aW5nEkoKEmRlZmF1bHRfdXNlcl9y",
+            "b2xlcxgLIAMoCzIcLmhlYWRsZXNzLnYxLkRlZmF1bHRVc2VyUm9sZVIQZGVm",
+            "YXVsdFVzZXJSb2xlcxIqChFhd2F5X2tpY2tfbWludXRlcxgMIAEoAlIPYXdh",
+            "eUtpY2tNaW51dGVzEkEKHWlkbGVfcmVzdGFydF9pbnRlcnZhbF9zZWNvbmRz",
+            "GA0gASgFUhppZGxlUmVzdGFydEludGVydmFsU2Vjb25kcxIgCgxzYXZlX29u",
+            "X2V4aXQYDiABKAhSCnNhdmVPbkV4aXQSOwoaYXV0b19zYXZlX2ludGVydmFs",
+            "X3NlY29uZHMYDyABKAVSF2F1dG9TYXZlSW50ZXJ2YWxTZWNvbmRzEh0KCmF1",
+            "dG9fc2xlZXAYECABKAhSCWF1dG9TbGVlcBJHCiBpbnZpdGVfcmVxdWVzdF9o",
+            "YW5kbGVyX3VzZXJuYW1lcxgRIAMoCVIdaW52aXRlUmVxdWVzdEhhbmRsZXJV",
+            "c2VybmFtZXMSHQoKZm9yY2VfcG9ydBgSIAEoDVIJZm9yY2VQb3J0EiwKEnBh",
+            "cmVudF9zZXNzaW9uX2lkcxgTIAMoCVIQcGFyZW50U2Vzc2lvbklkcxIhCgxh",
+            "dXRvX3JlY292ZXIYFCABKAhSC2F1dG9SZWNvdmVyEkUKH2ZvcmNlZF9yZXN0",
+            "YXJ0X2ludGVydmFsX3NlY29uZHMYFSABKAVSHGZvcmNlZFJlc3RhcnRJbnRl",
+            "cnZhbFNlY29uZHMSNwoYdXNlX2N1c3RvbV9qb2luX3ZlcmlmaWVyGBYgASgI",
+            "UhV1c2VDdXN0b21Kb2luVmVyaWZpZXISJwoPbW9iaWxlX2ZyaWVuZGx5GBcg",
+            "ASgIUg5tb2JpbGVGcmllbmRseRJhCh9vdmVycmlkZV9jb3JyZXNwb25kaW5n",
+            "X3dvcmxkX2lkGBggASgLMhUuaGVhZGxlc3MudjEuUmVjb3JkSWRIBVIcb3Zl",
+            "cnJpZGVDb3JyZXNwb25kaW5nV29ybGRJZIgBARIuChNrZWVwX29yaWdpbmFs",
+            "X3JvbGVzGBkgASgIUhFrZWVwT3JpZ2luYWxSb2xlcxIzChNyb2xlX2Nsb3Vk",
+            "X3ZhcmlhYmxlGBogASgJSAZSEXJvbGVDbG91ZFZhcmlhYmxliAEBEj4KGWFs",
+            "bG93X3VzZXJfY2xvdWRfdmFyaWFibGUYGyABKAlIB1IWYWxsb3dVc2VyQ2xv",
+            "dWRWYXJpYWJsZYgBARI8ChhkZW55X3VzZXJfY2xvdWRfdmFyaWFibGUYHCAB",
+            "KAlICFIVZGVueVVzZXJDbG91ZFZhcmlhYmxliAEBEk0KIXJlcXVpcmVkX3Vz",
+            "ZXJfam9pbl9jbG91ZF92YXJpYWJsZRgdIAEoCUgJUh1yZXF1aXJlZFVzZXJK",
+            "b2luQ2xvdWRWYXJpYWJsZYgBARJlCi5yZXF1aXJlZF91c2VyX2pvaW5fY2xv",
+            "dWRfdmFyaWFibGVfZGVueV9tZXNzYWdlGB4gASgJSApSKHJlcXVpcmVkVXNl",
+            "ckpvaW5DbG91ZFZhcmlhYmxlRGVueU1lc3NhZ2WIAQESMwoTYXV0b19pbnZp",
+            "dGVfbWVzc2FnZRgfIAEoCUgLUhFhdXRvSW52aXRlTWVzc2FnZYgBARIxChVq",
+            "b2luX2FsbG93ZWRfdXNlcl9pZHMYICADKAlSEmpvaW5BbGxvd2VkVXNlcklk",
+            "c0IMCgpsb2FkX3dvcmxkQgcKBV9uYW1lQhQKEl9jdXN0b21fc2Vzc2lvbl9p",
+            "ZEIOCgxfZGVzY3JpcHRpb25CDAoKX21heF91c2Vyc0IiCiBfb3ZlcnJpZGVf",
+            "Y29ycmVzcG9uZGluZ193b3JsZF9pZEIWChRfcm9sZV9jbG91ZF92YXJpYWJs",
+            "ZUIcChpfYWxsb3dfdXNlcl9jbG91ZF92YXJpYWJsZUIbChlfZGVueV91c2Vy",
+            "X2Nsb3VkX3ZhcmlhYmxlQiQKIl9yZXF1aXJlZF91c2VyX2pvaW5fY2xvdWRf",
+            "dmFyaWFibGVCMQovX3JlcXVpcmVkX3VzZXJfam9pbl9jbG91ZF92YXJpYWJs",
+            "ZV9kZW55X21lc3NhZ2VCFgoUX2F1dG9faW52aXRlX21lc3NhZ2UimQIKEkNv",
+            "bnRhY3RDaGF0TWVzc2FnZRIOCgJpZBgBIAEoCVICaWQSNwoEdHlwZRgCIAEo",
+            "DjIjLmhlYWRsZXNzLnYxLkNvbnRhY3RDaGF0TWVzc2FnZVR5cGVSBHR5cGUS",
+            "GAoHY29udGVudBgDIAEoCVIHY29udGVudBI3CglzZW5kX3RpbWUYBCABKAsy",
+            "Gi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wUghzZW5kVGltZRI8CglyZWFk",
+            "X3RpbWUYBSABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wSABSCHJl",
+            "YWRUaW1liAEBEhsKCXNlbmRlcl9pZBgGIAEoCVIIc2VuZGVySWRCDAoKX3Jl",
+            "YWRfdGltZSKmAgoSQWxsb3dlZEFjY2Vzc0VudHJ5EhIKBGhvc3QYASABKAlS",
+            "BGhvc3QSFAoFcG9ydHMYAiADKAVSBXBvcnRzEk0KDGFjY2Vzc190eXBlcxgD",
+            "IAMoDjIqLmhlYWRsZXNzLnYxLkFsbG93ZWRBY2Nlc3NFbnRyeS5BY2Nlc3NU",
+            "eXBlUgthY2Nlc3NUeXBlcyKWAQoKQWNjZXNzVHlwZRIbChdBQ0NFU1NfVFlQ",
+            "RV9VTlNQRUNJRklFRBAAEhQKEEFDQ0VTU19UWVBFX0hUVFAQARIZChVBQ0NF",
+            "U1NfVFlQRV9XRUJTT0NLRVQQAhIdChlBQ0NFU1NfVFlQRV9PU0NfUkVDRUlW",
+            "SU5HEAMSGwoXQUNDRVNTX1RZUEVfT1NDX1NFTkRJTkcQBCLpAwoNU3RhcnR1",
+            "cENvbmZpZxIkCgt1bml2ZXJzZV9pZBgBIAEoCUgAUgp1bml2ZXJzZUlkiAEB",
+            "EiAKCXRpY2tfcmF0ZRgCIAEoAkgBUgh0aWNrUmF0ZYgBARJICh5tYXhfY29u",
+            "Y3VycmVudF9hc3NldF90cmFuc2ZlcnMYAyABKAVIAlIbbWF4Q29uY3VycmVu",
+            "dEFzc2V0VHJhbnNmZXJziAEBEjAKEXVzZXJuYW1lX292ZXJyaWRlGAQgASgJ",
+            "SANSEHVzZXJuYW1lT3ZlcnJpZGWIAQESRgoMc3RhcnRfd29ybGRzGAUgAygL",
+            "MiMuaGVhZGxlc3MudjEuV29ybGRTdGFydHVwUGFyYW1ldGVyc1ILc3RhcnRX",
+            "b3JsZHMSSwoRYWxsb3dlZF91cmxfaG9zdHMYBiADKAsyHy5oZWFkbGVzcy52",
+            "MS5BbGxvd2VkQWNjZXNzRW50cnlSD2FsbG93ZWRVcmxIb3N0cxIoChBhdXRv",
+            "X3NwYXduX2l0ZW1zGAcgAygJUg5hdXRvU3Bhd25JdGVtc0IOCgxfdW5pdmVy",
+            "c2VfaWRCDAoKX3RpY2tfcmF0ZUIhCh9fbWF4X2NvbmN1cnJlbnRfYXNzZXRf",
+            "dHJhbnNmZXJzQhQKEl91c2VybmFtZV9vdmVycmlkZSI1CghSZWNvcmRJZBIO",
+            "CgJpZBgBIAEoCVICaWQSGQoIb3duZXJfaWQYAiABKAlSB293bmVySWQqoAEK",
+            "EVdvcmxkQmluYXJ5Rm9ybWF0EiMKH1dPUkxEX0JJTkFSWV9GT1JNQVRfVU5T",
+            "UEVDSUZJRUQQABIeChpXT1JMRF9CSU5BUllfRk9STUFUXzdaQlNPThABEh0K",
+            "GVdPUkxEX0JJTkFSWV9GT1JNQVRfQlJTT04QAhInCiNXT1JMRF9CSU5BUllf",
+            "Rk9STUFUX1JFU09OSVRFUEFDS0FHRRADKtIBCgtBY2Nlc3NMZXZlbBIcChhB",
+            "Q0NFU1NfTEVWRUxfVU5TUEVDSUZJRUQQABIYChRBQ0NFU1NfTEVWRUxfUFJJ",
+            "VkFURRABEhQKEEFDQ0VTU19MRVZFTF9MQU4QAhIZChVBQ0NFU1NfTEVWRUxf",
+            "Q09OVEFDVFMQAxIeChpBQ0NFU1NfTEVWRUxfQ09OVEFDVFNfUExVUxAEEiEK",
+            "HUFDQ0VTU19MRVZFTF9SRUdJU1RFUkVEX1VTRVJTEAUSFwoTQUNDRVNTX0xF",
+            "VkVMX0FOWU9ORRAGKuABChZDb250YWN0Q2hhdE1lc3NhZ2VUeXBlEikKJUNP",
+            "TlRBQ1RfQ0hBVF9NRVNTQUdFX1RZUEVfVU5TUEVDSUZJRUQQABIiCh5DT05U",
+            "QUNUX0NIQVRfTUVTU0FHRV9UWVBFX1RFWFQQARIkCiBDT05UQUNUX0NIQVRf",
+            "TUVTU0FHRV9UWVBFX09CSkVDVBACEiMKH0NPTlRBQ1RfQ0hBVF9NRVNTQUdF",
+            "X1RZUEVfU09VTkQQAxIsCihDT05UQUNUX0NIQVRfTUVTU0FHRV9UWVBFX1NF",
+            "U1NJT05fSU5WSVRFEAQy5RUKFkhlYWRsZXNzQ29udHJvbFNlcnZpY2USRwoI",
+            "R2V0QWJvdXQSHC5oZWFkbGVzcy52MS5HZXRBYm91dFJlcXVlc3QaHS5oZWFk",
+            "bGVzcy52MS5HZXRBYm91dFJlc3BvbnNlEkoKCUdldFN0YXR1cxIdLmhlYWRs",
+            "ZXNzLnYxLkdldFN0YXR1c1JlcXVlc3QaHi5oZWFkbGVzcy52MS5HZXRTdGF0",
+            "dXNSZXNwb25zZRJHCghTaHV0ZG93bhIcLmhlYWRsZXNzLnYxLlNodXRkb3du",
+            "UmVxdWVzdBodLmhlYWRsZXNzLnYxLlNodXRkb3duUmVzcG9uc2USUwoMTGlz",
+            "dFNlc3Npb25zEiAuaGVhZGxlc3MudjEuTGlzdFNlc3Npb25zUmVxdWVzdBoh",
+            "LmhlYWRsZXNzLnYxLkxpc3RTZXNzaW9uc1Jlc3BvbnNlEk0KCkdldFNlc3Np",
+            "b24SHi5oZWFkbGVzcy52MS5HZXRTZXNzaW9uUmVxdWVzdBofLmhlYWRsZXNz",
+            "LnYxLkdldFNlc3Npb25SZXNwb25zZRJNCgpTdGFydFdvcmxkEh4uaGVhZGxl",
+            "c3MudjEuU3RhcnRXb3JsZFJlcXVlc3QaHy5oZWFkbGVzcy52MS5TdGFydFdv",
+            "cmxkUmVzcG9uc2USUAoLU3RvcFNlc3Npb24SHy5oZWFkbGVzcy52MS5TdG9w",
+            "U2Vzc2lvblJlcXVlc3QaIC5oZWFkbGVzcy52MS5TdG9wU2Vzc2lvblJlc3Bv",
+            "bnNlEl8KEFNhdmVTZXNzaW9uV29ybGQSJC5oZWFkbGVzcy52MS5TYXZlU2Vz",
+            "c2lvbldvcmxkUmVxdWVzdBolLmhlYWRsZXNzLnYxLlNhdmVTZXNzaW9uV29y",
+            "bGRSZXNwb25zZRJlChJTYXZlQXNTZXNzaW9uV29ybGQSJi5oZWFkbGVzcy52",
+            "MS5TYXZlQXNTZXNzaW9uV29ybGRSZXF1ZXN0GicuaGVhZGxlc3MudjEuU2F2",
+            "ZUFzU2Vzc2lvbldvcmxkUmVzcG9uc2USTQoKSW52aXRlVXNlchIeLmhlYWRs",
+            "ZXNzLnYxLkludml0ZVVzZXJSZXF1ZXN0Gh8uaGVhZGxlc3MudjEuSW52aXRl",
+            "VXNlclJlc3BvbnNlElwKD0FsbG93VXNlclRvSm9pbhIjLmhlYWRsZXNzLnYx",
+            "LkFsbG93VXNlclRvSm9pblJlcXVlc3QaJC5oZWFkbGVzcy52MS5BbGxvd1Vz",
+            "ZXJUb0pvaW5SZXNwb25zZRJZCg5VcGRhdGVVc2VyUm9sZRIiLmhlYWRsZXNz",
+            "LnYxLlVwZGF0ZVVzZXJSb2xlUmVxdWVzdBojLmhlYWRsZXNzLnYxLlVwZGF0",
+            "ZVVzZXJSb2xlUmVzcG9uc2USdAoXVXBkYXRlU2Vzc2lvblBhcmFtZXRlcnMS",
+            "Ky5oZWFkbGVzcy52MS5VcGRhdGVTZXNzaW9uUGFyYW1ldGVyc1JlcXVlc3Qa",
+            "LC5oZWFkbGVzcy52MS5VcGRhdGVTZXNzaW9uUGFyYW1ldGVyc1Jlc3BvbnNl",
+            "EmUKEkxpc3RVc2Vyc0luU2Vzc2lvbhImLmhlYWRsZXNzLnYxLkxpc3RVc2Vy",
+            "c0luU2Vzc2lvblJlcXVlc3QaJy5oZWFkbGVzcy52MS5MaXN0VXNlcnNJblNl",
+            "c3Npb25SZXNwb25zZRJHCghLaWNrVXNlchIcLmhlYWRsZXNzLnYxLktpY2tV",
+            "c2VyUmVxdWVzdBodLmhlYWRsZXNzLnYxLktpY2tVc2VyUmVzcG9uc2USRAoH",
+            "QmFuVXNlchIbLmhlYWRsZXNzLnYxLkJhblVzZXJSZXF1ZXN0GhwuaGVhZGxl",
+            "c3MudjEuQmFuVXNlclJlc3BvbnNlElwKD0dldEhvc3RTZXR0aW5ncxIjLmhl",
+            "YWRsZXNzLnYxLkdldEhvc3RTZXR0aW5nc1JlcXVlc3QaJC5oZWFkbGVzcy52",
+            "MS5HZXRIb3N0U2V0dGluZ3NSZXNwb25zZRJlChJVcGRhdGVIb3N0U2V0dGlu",
+            "Z3MSJi5oZWFkbGVzcy52MS5VcGRhdGVIb3N0U2V0dGluZ3NSZXF1ZXN0Gicu",
+            "aGVhZGxlc3MudjEuVXBkYXRlSG9zdFNldHRpbmdzUmVzcG9uc2USXAoPQWxs",
+            "b3dIb3N0QWNjZXNzEiMuaGVhZGxlc3MudjEuQWxsb3dIb3N0QWNjZXNzUmVx",
+            "dWVzdBokLmhlYWRsZXNzLnYxLkFsbG93SG9zdEFjY2Vzc1Jlc3BvbnNlElkK",
+            "DkRlbnlIb3N0QWNjZXNzEiIuaGVhZGxlc3MudjEuRGVueUhvc3RBY2Nlc3NS",
+            "ZXF1ZXN0GiMuaGVhZGxlc3MudjEuRGVueUhvc3RBY2Nlc3NSZXNwb25zZRJ6",
+            "ChlHZXRTdGFydHVwQ29uZmlnVG9SZXN0b3JlEi0uaGVhZGxlc3MudjEuR2V0",
+            "U3RhcnR1cENvbmZpZ1RvUmVzdG9yZVJlcXVlc3QaLi5oZWFkbGVzcy52MS5H",
+            "ZXRTdGFydHVwQ29uZmlnVG9SZXN0b3JlUmVzcG9uc2USbQoURG93bmxvYWRT",
+            "ZXNzaW9uV29ybGQSKC5oZWFkbGVzcy52MS5Eb3dubG9hZFNlc3Npb25Xb3Js",
+            "ZFJlcXVlc3QaKS5oZWFkbGVzcy52MS5Eb3dubG9hZFNlc3Npb25Xb3JsZFJl",
+            "c3BvbnNlMAESWQoOR2V0QWNjb3VudEluZm8SIi5oZWFkbGVzcy52MS5HZXRB",
+            "Y2NvdW50SW5mb1JlcXVlc3QaIy5oZWFkbGVzcy52MS5HZXRBY2NvdW50SW5m",
+            "b1Jlc3BvbnNlElkKDkZldGNoV29ybGRJbmZvEiIuaGVhZGxlc3MudjEuRmV0",
+            "Y2hXb3JsZEluZm9SZXF1ZXN0GiMuaGVhZGxlc3MudjEuRmV0Y2hXb3JsZElu",
+            "Zm9SZXNwb25zZRJZCg5TZWFyY2hVc2VySW5mbxIiLmhlYWRsZXNzLnYxLlNl",
+            "YXJjaFVzZXJJbmZvUmVxdWVzdBojLmhlYWRsZXNzLnYxLlNlYXJjaFVzZXJJ",
+            "bmZvUmVzcG9uc2USYgoRR2V0RnJpZW5kUmVxdWVzdHMSJS5oZWFkbGVzcy52",
+            "MS5HZXRGcmllbmRSZXF1ZXN0c1JlcXVlc3QaJi5oZWFkbGVzcy52MS5HZXRG",
+            "cmllbmRSZXF1ZXN0c1Jlc3BvbnNlEmsKFEFjY2VwdEZyaWVuZFJlcXVlc3Rz",
+            "EiguaGVhZGxlc3MudjEuQWNjZXB0RnJpZW5kUmVxdWVzdHNSZXF1ZXN0Giku",
+            "aGVhZGxlc3MudjEuQWNjZXB0RnJpZW5kUmVxdWVzdHNSZXNwb25zZRJTCgxM",
+            "aXN0Q29udGFjdHMSIC5oZWFkbGVzcy52MS5MaXN0Q29udGFjdHNSZXF1ZXN0",
+            "GiEuaGVhZGxlc3MudjEuTGlzdENvbnRhY3RzUmVzcG9uc2USZQoSR2V0Q29u",
+            "dGFjdE1lc3NhZ2VzEiYuaGVhZGxlc3MudjEuR2V0Q29udGFjdE1lc3NhZ2Vz",
+            "UmVxdWVzdBonLmhlYWRsZXNzLnYxLkdldENvbnRhY3RNZXNzYWdlc1Jlc3Bv",
+            "bnNlEmUKElNlbmRDb250YWN0TWVzc2FnZRImLmhlYWRsZXNzLnYxLlNlbmRD",
+            "b250YWN0TWVzc2FnZVJlcXVlc3QaJy5oZWFkbGVzcy52MS5TZW5kQ29udGFj",
+            "dE1lc3NhZ2VSZXNwb25zZUIPqgIMSGVhZGxlc3MuUnBjYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Headless.Rpc.AccessLevel), typeof(global::Headless.Rpc.ContactChatMessageType), }, null, new pbr::GeneratedClrTypeInfo[] {
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Headless.Rpc.WorldBinaryFormat), typeof(global::Headless.Rpc.AccessLevel), typeof(global::Headless.Rpc.ContactChatMessageType), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.GetStartupConfigToRestoreRequest), global::Headless.Rpc.GetStartupConfigToRestoreRequest.Parser, new[]{ "IncludeStartWorlds" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.GetStartupConfigToRestoreResponse), global::Headless.Rpc.GetStartupConfigToRestoreResponse.Parser, new[]{ "StartupConfig" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.GetHostSettingsRequest), global::Headless.Rpc.GetHostSettingsRequest.Parser, null, null, null, null, null),
@@ -394,6 +406,8 @@ namespace Headless.Rpc {
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.SaveSessionWorldResponse), global::Headless.Rpc.SaveSessionWorldResponse.Parser, null, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.SaveAsSessionWorldRequest), global::Headless.Rpc.SaveAsSessionWorldRequest.Parser, new[]{ "SessionId", "Type" }, null, new[]{ typeof(global::Headless.Rpc.SaveAsSessionWorldRequest.Types.SaveAsType) }, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.SaveAsSessionWorldResponse), global::Headless.Rpc.SaveAsSessionWorldResponse.Parser, new[]{ "SavedRecordUrl" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.DownloadSessionWorldRequest), global::Headless.Rpc.DownloadSessionWorldRequest.Parser, new[]{ "SessionId", "Format", "IncludeVariants", "BrotliQuality" }, new[]{ "IncludeVariants", "BrotliQuality" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.DownloadSessionWorldResponse), global::Headless.Rpc.DownloadSessionWorldResponse.Parser, new[]{ "Chunk" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.InviteUserRequest), global::Headless.Rpc.InviteUserRequest.Parser, new[]{ "SessionId", "UserId", "UserName" }, new[]{ "User" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.InviteUserResponse), global::Headless.Rpc.InviteUserResponse.Parser, null, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Headless.Rpc.AllowUserToJoinRequest), global::Headless.Rpc.AllowUserToJoinRequest.Parser, new[]{ "SessionId", "UserId" }, null, null, null, null),
@@ -419,6 +433,13 @@ namespace Headless.Rpc {
 
   }
   #region Enums
+  public enum WorldBinaryFormat {
+    [pbr::OriginalName("WORLD_BINARY_FORMAT_UNSPECIFIED")] Unspecified = 0,
+    [pbr::OriginalName("WORLD_BINARY_FORMAT_7ZBSON")] _7Zbson = 1,
+    [pbr::OriginalName("WORLD_BINARY_FORMAT_BRSON")] Brson = 2,
+    [pbr::OriginalName("WORLD_BINARY_FORMAT_RESONITEPACKAGE")] Resonitepackage = 3,
+  }
+
   public enum AccessLevel {
     [pbr::OriginalName("ACCESS_LEVEL_UNSPECIFIED")] Unspecified = 0,
     [pbr::OriginalName("ACCESS_LEVEL_PRIVATE")] Private = 1,
@@ -11177,6 +11198,551 @@ namespace Headless.Rpc {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class DownloadSessionWorldRequest : pb::IMessage<DownloadSessionWorldRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<DownloadSessionWorldRequest> _parser = new pb::MessageParser<DownloadSessionWorldRequest>(() => new DownloadSessionWorldRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    private int _hasBits0;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<DownloadSessionWorldRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[48]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public DownloadSessionWorldRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public DownloadSessionWorldRequest(DownloadSessionWorldRequest other) : this() {
+      _hasBits0 = other._hasBits0;
+      sessionId_ = other.sessionId_;
+      format_ = other.format_;
+      includeVariants_ = other.includeVariants_;
+      brotliQuality_ = other.brotliQuality_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public DownloadSessionWorldRequest Clone() {
+      return new DownloadSessionWorldRequest(this);
+    }
+
+    /// <summary>Field number for the "session_id" field.</summary>
+    public const int SessionIdFieldNumber = 1;
+    private string sessionId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string SessionId {
+      get { return sessionId_; }
+      set {
+        sessionId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "format" field.</summary>
+    public const int FormatFieldNumber = 2;
+    private global::Headless.Rpc.WorldBinaryFormat format_ = global::Headless.Rpc.WorldBinaryFormat.Unspecified;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Headless.Rpc.WorldBinaryFormat Format {
+      get { return format_; }
+      set {
+        format_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "include_variants" field.</summary>
+    public const int IncludeVariantsFieldNumber = 3;
+    private readonly static bool IncludeVariantsDefaultValue = false;
+
+    private bool includeVariants_;
+    /// <summary>
+    /// resonitepackage 用。他フォーマットでは無視
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool IncludeVariants {
+      get { if ((_hasBits0 & 1) != 0) { return includeVariants_; } else { return IncludeVariantsDefaultValue; } }
+      set {
+        _hasBits0 |= 1;
+        includeVariants_ = value;
+      }
+    }
+    /// <summary>Gets whether the "include_variants" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasIncludeVariants {
+      get { return (_hasBits0 & 1) != 0; }
+    }
+    /// <summary>Clears the value of the "include_variants" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearIncludeVariants() {
+      _hasBits0 &= ~1;
+    }
+
+    /// <summary>Field number for the "brotli_quality" field.</summary>
+    public const int BrotliQualityFieldNumber = 4;
+    private readonly static int BrotliQualityDefaultValue = 0;
+
+    private int brotliQuality_;
+    /// <summary>
+    /// BRSON 用 quality (0-11)。未指定時はデフォルト値を使用
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int BrotliQuality {
+      get { if ((_hasBits0 & 2) != 0) { return brotliQuality_; } else { return BrotliQualityDefaultValue; } }
+      set {
+        _hasBits0 |= 2;
+        brotliQuality_ = value;
+      }
+    }
+    /// <summary>Gets whether the "brotli_quality" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasBrotliQuality {
+      get { return (_hasBits0 & 2) != 0; }
+    }
+    /// <summary>Clears the value of the "brotli_quality" field</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearBrotliQuality() {
+      _hasBits0 &= ~2;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as DownloadSessionWorldRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(DownloadSessionWorldRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (SessionId != other.SessionId) return false;
+      if (Format != other.Format) return false;
+      if (IncludeVariants != other.IncludeVariants) return false;
+      if (BrotliQuality != other.BrotliQuality) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (SessionId.Length != 0) hash ^= SessionId.GetHashCode();
+      if (Format != global::Headless.Rpc.WorldBinaryFormat.Unspecified) hash ^= Format.GetHashCode();
+      if (HasIncludeVariants) hash ^= IncludeVariants.GetHashCode();
+      if (HasBrotliQuality) hash ^= BrotliQuality.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (SessionId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(SessionId);
+      }
+      if (Format != global::Headless.Rpc.WorldBinaryFormat.Unspecified) {
+        output.WriteRawTag(16);
+        output.WriteEnum((int) Format);
+      }
+      if (HasIncludeVariants) {
+        output.WriteRawTag(24);
+        output.WriteBool(IncludeVariants);
+      }
+      if (HasBrotliQuality) {
+        output.WriteRawTag(32);
+        output.WriteInt32(BrotliQuality);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (SessionId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(SessionId);
+      }
+      if (Format != global::Headless.Rpc.WorldBinaryFormat.Unspecified) {
+        output.WriteRawTag(16);
+        output.WriteEnum((int) Format);
+      }
+      if (HasIncludeVariants) {
+        output.WriteRawTag(24);
+        output.WriteBool(IncludeVariants);
+      }
+      if (HasBrotliQuality) {
+        output.WriteRawTag(32);
+        output.WriteInt32(BrotliQuality);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (SessionId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(SessionId);
+      }
+      if (Format != global::Headless.Rpc.WorldBinaryFormat.Unspecified) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Format);
+      }
+      if (HasIncludeVariants) {
+        size += 1 + 1;
+      }
+      if (HasBrotliQuality) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(BrotliQuality);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(DownloadSessionWorldRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.SessionId.Length != 0) {
+        SessionId = other.SessionId;
+      }
+      if (other.Format != global::Headless.Rpc.WorldBinaryFormat.Unspecified) {
+        Format = other.Format;
+      }
+      if (other.HasIncludeVariants) {
+        IncludeVariants = other.IncludeVariants;
+      }
+      if (other.HasBrotliQuality) {
+        BrotliQuality = other.BrotliQuality;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            SessionId = input.ReadString();
+            break;
+          }
+          case 16: {
+            Format = (global::Headless.Rpc.WorldBinaryFormat) input.ReadEnum();
+            break;
+          }
+          case 24: {
+            IncludeVariants = input.ReadBool();
+            break;
+          }
+          case 32: {
+            BrotliQuality = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            SessionId = input.ReadString();
+            break;
+          }
+          case 16: {
+            Format = (global::Headless.Rpc.WorldBinaryFormat) input.ReadEnum();
+            break;
+          }
+          case 24: {
+            IncludeVariants = input.ReadBool();
+            break;
+          }
+          case 32: {
+            BrotliQuality = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class DownloadSessionWorldResponse : pb::IMessage<DownloadSessionWorldResponse>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<DownloadSessionWorldResponse> _parser = new pb::MessageParser<DownloadSessionWorldResponse>(() => new DownloadSessionWorldResponse());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<DownloadSessionWorldResponse> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[49]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public DownloadSessionWorldResponse() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public DownloadSessionWorldResponse(DownloadSessionWorldResponse other) : this() {
+      chunk_ = other.chunk_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public DownloadSessionWorldResponse Clone() {
+      return new DownloadSessionWorldResponse(this);
+    }
+
+    /// <summary>Field number for the "chunk" field.</summary>
+    public const int ChunkFieldNumber = 1;
+    private pb::ByteString chunk_ = pb::ByteString.Empty;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString Chunk {
+      get { return chunk_; }
+      set {
+        chunk_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as DownloadSessionWorldResponse);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(DownloadSessionWorldResponse other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Chunk != other.Chunk) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Chunk.Length != 0) hash ^= Chunk.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Chunk.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteBytes(Chunk);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Chunk.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteBytes(Chunk);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Chunk.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(Chunk);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(DownloadSessionWorldResponse other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Chunk.Length != 0) {
+        Chunk = other.Chunk;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            Chunk = input.ReadBytes();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            Chunk = input.ReadBytes();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class InviteUserRequest : pb::IMessage<InviteUserRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -11191,7 +11757,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[48]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[50]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11524,7 +12090,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[49]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[51]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11685,7 +12251,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[50]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[52]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11920,7 +12486,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[51]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[53]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12081,7 +12647,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[52]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[54]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12451,7 +13017,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[53]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[55]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12653,7 +13219,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[54]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[56]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13838,7 +14404,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[55]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[57]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13999,7 +14565,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[56]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[58]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14197,7 +14763,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[57]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[59]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14384,7 +14950,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[58]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[60]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14693,7 +15259,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[59]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[61]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14965,7 +15531,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[60]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[62]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15997,7 +16563,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[61]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[63]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16233,7 +16799,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[62]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[64]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -17724,7 +18290,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[63]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[65]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -18125,7 +18691,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[64]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[66]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -18396,7 +18962,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[65]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[67]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -18842,7 +19408,7 @@ namespace Headless.Rpc {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[66]; }
+      get { return global::Headless.Rpc.HeadlessReflection.Descriptor.MessageTypes[68]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/Headless/Protos/HeadlessGrpc.cs
+++ b/Headless/Protos/HeadlessGrpc.cs
@@ -130,6 +130,10 @@ namespace Headless.Rpc {
     [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
     static readonly grpc::Marshaller<global::Headless.Rpc.GetStartupConfigToRestoreResponse> __Marshaller_headless_v1_GetStartupConfigToRestoreResponse = grpc::Marshallers.Create(__Helper_SerializeMessage, context => __Helper_DeserializeMessage(context, global::Headless.Rpc.GetStartupConfigToRestoreResponse.Parser));
     [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+    static readonly grpc::Marshaller<global::Headless.Rpc.DownloadSessionWorldRequest> __Marshaller_headless_v1_DownloadSessionWorldRequest = grpc::Marshallers.Create(__Helper_SerializeMessage, context => __Helper_DeserializeMessage(context, global::Headless.Rpc.DownloadSessionWorldRequest.Parser));
+    [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+    static readonly grpc::Marshaller<global::Headless.Rpc.DownloadSessionWorldResponse> __Marshaller_headless_v1_DownloadSessionWorldResponse = grpc::Marshallers.Create(__Helper_SerializeMessage, context => __Helper_DeserializeMessage(context, global::Headless.Rpc.DownloadSessionWorldResponse.Parser));
+    [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
     static readonly grpc::Marshaller<global::Headless.Rpc.GetAccountInfoRequest> __Marshaller_headless_v1_GetAccountInfoRequest = grpc::Marshallers.Create(__Helper_SerializeMessage, context => __Helper_DeserializeMessage(context, global::Headless.Rpc.GetAccountInfoRequest.Parser));
     [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
     static readonly grpc::Marshaller<global::Headless.Rpc.GetAccountInfoResponse> __Marshaller_headless_v1_GetAccountInfoResponse = grpc::Marshallers.Create(__Helper_SerializeMessage, context => __Helper_DeserializeMessage(context, global::Headless.Rpc.GetAccountInfoResponse.Parser));
@@ -331,6 +335,14 @@ namespace Headless.Rpc {
         __Marshaller_headless_v1_GetStartupConfigToRestoreResponse);
 
     [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+    static readonly grpc::Method<global::Headless.Rpc.DownloadSessionWorldRequest, global::Headless.Rpc.DownloadSessionWorldResponse> __Method_DownloadSessionWorld = new grpc::Method<global::Headless.Rpc.DownloadSessionWorldRequest, global::Headless.Rpc.DownloadSessionWorldResponse>(
+        grpc::MethodType.ServerStreaming,
+        __ServiceName,
+        "DownloadSessionWorld",
+        __Marshaller_headless_v1_DownloadSessionWorldRequest,
+        __Marshaller_headless_v1_DownloadSessionWorldResponse);
+
+    [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
     static readonly grpc::Method<global::Headless.Rpc.GetAccountInfoRequest, global::Headless.Rpc.GetAccountInfoResponse> __Method_GetAccountInfo = new grpc::Method<global::Headless.Rpc.GetAccountInfoRequest, global::Headless.Rpc.GetAccountInfoResponse>(
         grpc::MethodType.Unary,
         __ServiceName,
@@ -526,6 +538,12 @@ namespace Headless.Rpc {
 
       [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
       public virtual global::System.Threading.Tasks.Task<global::Headless.Rpc.GetStartupConfigToRestoreResponse> GetStartupConfigToRestore(global::Headless.Rpc.GetStartupConfigToRestoreRequest request, grpc::ServerCallContext context)
+      {
+        throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
+      }
+
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual global::System.Threading.Tasks.Task DownloadSessionWorld(global::Headless.Rpc.DownloadSessionWorldRequest request, grpc::IServerStreamWriter<global::Headless.Rpc.DownloadSessionWorldResponse> responseStream, grpc::ServerCallContext context)
       {
         throw new grpc::RpcException(new grpc::Status(grpc::StatusCode.Unimplemented, ""));
       }
@@ -1033,6 +1051,16 @@ namespace Headless.Rpc {
       {
         return CallInvoker.AsyncUnaryCall(__Method_GetStartupConfigToRestore, null, options, request);
       }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual grpc::AsyncServerStreamingCall<global::Headless.Rpc.DownloadSessionWorldResponse> DownloadSessionWorld(global::Headless.Rpc.DownloadSessionWorldRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      {
+        return DownloadSessionWorld(request, new grpc::CallOptions(headers, deadline, cancellationToken));
+      }
+      [global::System.CodeDom.Compiler.GeneratedCode("grpc_csharp_plugin", null)]
+      public virtual grpc::AsyncServerStreamingCall<global::Headless.Rpc.DownloadSessionWorldResponse> DownloadSessionWorld(global::Headless.Rpc.DownloadSessionWorldRequest request, grpc::CallOptions options)
+      {
+        return CallInvoker.AsyncServerStreamingCall(__Method_DownloadSessionWorld, null, options, request);
+      }
       /// <summary>
       /// Cloud系
       /// </summary>
@@ -1256,6 +1284,7 @@ namespace Headless.Rpc {
           .AddMethod(__Method_AllowHostAccess, serviceImpl.AllowHostAccess)
           .AddMethod(__Method_DenyHostAccess, serviceImpl.DenyHostAccess)
           .AddMethod(__Method_GetStartupConfigToRestore, serviceImpl.GetStartupConfigToRestore)
+          .AddMethod(__Method_DownloadSessionWorld, serviceImpl.DownloadSessionWorld)
           .AddMethod(__Method_GetAccountInfo, serviceImpl.GetAccountInfo)
           .AddMethod(__Method_FetchWorldInfo, serviceImpl.FetchWorldInfo)
           .AddMethod(__Method_SearchUserInfo, serviceImpl.SearchUserInfo)
@@ -1294,6 +1323,7 @@ namespace Headless.Rpc {
       serviceBinder.AddMethod(__Method_AllowHostAccess, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Headless.Rpc.AllowHostAccessRequest, global::Headless.Rpc.AllowHostAccessResponse>(serviceImpl.AllowHostAccess));
       serviceBinder.AddMethod(__Method_DenyHostAccess, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Headless.Rpc.DenyHostAccessRequest, global::Headless.Rpc.DenyHostAccessResponse>(serviceImpl.DenyHostAccess));
       serviceBinder.AddMethod(__Method_GetStartupConfigToRestore, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Headless.Rpc.GetStartupConfigToRestoreRequest, global::Headless.Rpc.GetStartupConfigToRestoreResponse>(serviceImpl.GetStartupConfigToRestore));
+      serviceBinder.AddMethod(__Method_DownloadSessionWorld, serviceImpl == null ? null : new grpc::ServerStreamingServerMethod<global::Headless.Rpc.DownloadSessionWorldRequest, global::Headless.Rpc.DownloadSessionWorldResponse>(serviceImpl.DownloadSessionWorld));
       serviceBinder.AddMethod(__Method_GetAccountInfo, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Headless.Rpc.GetAccountInfoRequest, global::Headless.Rpc.GetAccountInfoResponse>(serviceImpl.GetAccountInfo));
       serviceBinder.AddMethod(__Method_FetchWorldInfo, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Headless.Rpc.FetchWorldInfoRequest, global::Headless.Rpc.FetchWorldInfoResponse>(serviceImpl.FetchWorldInfo));
       serviceBinder.AddMethod(__Method_SearchUserInfo, serviceImpl == null ? null : new grpc::UnaryServerMethod<global::Headless.Rpc.SearchUserInfoRequest, global::Headless.Rpc.SearchUserInfoResponse>(serviceImpl.SearchUserInfo));

--- a/Headless/Services/GrpcControllerService.cs
+++ b/Headless/Services/GrpcControllerService.cs
@@ -1,4 +1,5 @@
 using FrooxEngine;
+using Google.Protobuf;
 using Grpc.Core;
 using SkyFrost.Base;
 using Headless.Rpc;
@@ -146,6 +147,71 @@ public class GrpcControllerService : HeadlessControlService.HeadlessControlServi
         {
             SavedRecordUrl = saved.GetUrl(session.Instance.Engine.Cloud.Platform).ToString()
         };
+    }
+
+    public override async Task DownloadSessionWorld(
+        DownloadSessionWorldRequest request,
+        IServerStreamWriter<DownloadSessionWorldResponse> responseStream,
+        ServerCallContext context)
+    {
+        var session = _worldService.GetSession(request.SessionId);
+        if (session is null)
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "Session not found"));
+        }
+        if (request.Format == WorldBinaryFormat.Unspecified)
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "Require valid format"));
+        }
+        if (!session.Instance.IsAllowedToSaveWorld())
+        {
+            throw new RpcException(new Status(StatusCode.FailedPrecondition, "World is not allowed to be saved"));
+        }
+
+        var ct = context.CancellationToken;
+        // SDK の書き出し API (LZMAHelper.Compress / PackageCreator.BuildPackage) は
+        // 出力ストリームに対し Position/SetLength を要求するためシーク可能なバッキングが必須。
+        // テンポラリファイルへ書き出してからチャンク送信する。
+        var tmpPath = Path.Combine(Path.GetTempPath(), $"headless-export-{Guid.NewGuid():N}.bin");
+        try
+        {
+            try
+            {
+                await using (var fs = new FileStream(tmpPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 81920, FileOptions.SequentialScan))
+                {
+                    await session.ExportWorldBinaryAsync(
+                        request.Format,
+                        fs,
+                        request.HasIncludeVariants && request.IncludeVariants,
+                        request.HasBrotliQuality ? request.BrotliQuality : null,
+                        ct);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new RpcException(new Status(StatusCode.Internal, $"Failed to export world: {ex.Message}"));
+            }
+
+            await using var read = new FileStream(tmpPath, FileMode.Open, FileAccess.Read, FileShare.None, 81920, FileOptions.SequentialScan | FileOptions.Asynchronous);
+            var buffer = new byte[64 * 1024];
+            while (true)
+            {
+                var n = await read.ReadAsync(buffer.AsMemory(0, buffer.Length), ct);
+                if (n == 0) break;
+                await responseStream.WriteAsync(new DownloadSessionWorldResponse
+                {
+                    Chunk = ByteString.CopyFrom(buffer, 0, n),
+                }, ct);
+            }
+        }
+        finally
+        {
+            try { File.Delete(tmpPath); } catch { /* swallow */ }
+        }
     }
 
     public override async Task<InviteUserResponse> InviteUser(InviteUserRequest request, ServerCallContext context)

--- a/proto/headless/v1/headless.proto
+++ b/proto/headless/v1/headless.proto
@@ -28,6 +28,7 @@ service HeadlessControlService {
   rpc AllowHostAccess(AllowHostAccessRequest) returns (AllowHostAccessResponse);
   rpc DenyHostAccess(DenyHostAccessRequest) returns (DenyHostAccessResponse);
   rpc GetStartupConfigToRestore(GetStartupConfigToRestoreRequest) returns (GetStartupConfigToRestoreResponse);
+  rpc DownloadSessionWorld(DownloadSessionWorldRequest) returns (stream DownloadSessionWorldResponse);
 
   // Cloud系
   rpc GetAccountInfo(GetAccountInfoRequest) returns (GetAccountInfoResponse);
@@ -252,6 +253,19 @@ message SaveAsSessionWorldResponse {
   string saved_record_url = 1;
 }
 
+message DownloadSessionWorldRequest {
+  string session_id = 1;
+  WorldBinaryFormat format = 2;
+  // resonitepackage 用。他フォーマットでは無視
+  optional bool include_variants = 3;
+  // BRSON 用 quality (0-11)。未指定時はデフォルト値を使用
+  optional int32 brotli_quality = 4;
+}
+
+message DownloadSessionWorldResponse {
+  bytes chunk = 1;
+}
+
 message InviteUserRequest {
   string session_id = 1;
   oneof user {
@@ -318,6 +332,13 @@ message ListUsersInSessionResponse {
 }
 
 // models
+
+enum WorldBinaryFormat {
+  WORLD_BINARY_FORMAT_UNSPECIFIED = 0;
+  WORLD_BINARY_FORMAT_7ZBSON = 1;
+  WORLD_BINARY_FORMAT_BRSON = 2;
+  WORLD_BINARY_FORMAT_RESONITEPACKAGE = 3;
+}
 
 enum AccessLevel {
   ACCESS_LEVEL_UNSPECIFIED = 0;


### PR DESCRIPTION
## Summary
- `DownloadSessionWorld` server-streaming RPC を追加。`session_id` と `WorldBinaryFormat`(`7ZBSON` / `BRSON` / `RESONITEPACKAGE`) を指定して、実行中ワールドをバイナリでダウンロードできる。
- 大きいワールド向けに gRPC のチャンクで返却 (デフォルトの 4MB 制限を回避)。SDK 側の出力 API がシーク可能なストリームを要求するため、サーバ側で一時ファイルに書き出してからチャンク送信する実装。
- `7zbson` / `brson` は `World.SaveWorld()` の SavedGraph を `DataTreeConverter` で書き出し → Resonite では world として開ける。
- `resonitepackage` は SDK の `PackageImporter` が `RecordType == "object"` のみ受け付けるため、`Instance.RootSlot.SaveObject(...)` で object として保存し、`PackageCreator.BuildPackage` で梱包。

## Test plan
- [x] `make build.proto` / `dotnet build Headless/Headless.csproj` が通る
- [x] ローカル起動 → `Grid` プリセットでセッション起動 → `grpcurl` で 3 フォーマットそれぞれ取得
  - 7zbson: ヘッダ `FrDT\0\0\0\0` + LZMA(=02) ✓
  - brson: ヘッダ `FrDT\0\0\0\0` + Brotli(=03) ✓
  - resonitepackage: ZIP マジック + `R-Main.record` (recordType=object, name=session 名) ✓
- [x] resonitepackage を Resonite クライアントでインポートできることを確認 (報告ベース)