### PR TITLE
fix: Resonite 2026.6.18.634 で UpdateInput が NRE を投げてエンジン停止する問題を回避

### DIFF
--- a/EnginePrePatcher/Patches/NoOpUpdateInput.cs
+++ b/EnginePrePatcher/Patches/NoOpUpdateInput.cs
@@ -1,0 +1,42 @@
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace EnginePrePatcher.Patches;
+
+/// <summary>
+/// FrooxEngine.Engine.UpdateInput() throws NullReferenceException in headless mode (no input drivers
+/// registered), which leaves Engine.UpdateStep stuck at the InputUpdate stage and prevents the world
+/// coroutines from running. Replace its body with a no-op so the update loop advances.
+/// </summary>
+public class NoOpUpdateInput : IAssemblyPatch
+{
+    public string TargetAssemblyPath => "FrooxEngine.dll";
+
+    public IEnumerable<string> RemoveFiles => Array.Empty<string>();
+
+    public bool Patch(AssemblyDefinition assembly)
+    {
+        var engineType = assembly.MainModule.GetType("FrooxEngine.Engine");
+        if (engineType is null)
+        {
+            Console.WriteLine("FrooxEngine.Engine type not found");
+            return false;
+        }
+
+        var updateInput = engineType.Methods.FirstOrDefault(m =>
+            m.Name == "UpdateInput" && m.Parameters.Count == 0);
+        if (updateInput is null)
+        {
+            Console.WriteLine("FrooxEngine.Engine.UpdateInput() method not found");
+            return false;
+        }
+
+        updateInput.Body.Instructions.Clear();
+        updateInput.Body.ExceptionHandlers.Clear();
+        updateInput.Body.Variables.Clear();
+        var il = updateInput.Body.GetILProcessor();
+        il.Append(il.Create(OpCodes.Ret));
+        Console.WriteLine("Patched FrooxEngine.Engine.UpdateInput() to no-op");
+        return true;
+    }
+}

--- a/Headless.Tests/IntegrationTests/ContainerStartupTests.cs
+++ b/Headless.Tests/IntegrationTests/ContainerStartupTests.cs
@@ -25,8 +25,13 @@ public class ContainerStartupTests
             TimeSpan.FromMinutes(5));
 
         // Assert
-        Assert.True(result,
-            "Engine Ready! message was not found in container logs within 5 minutes. " +
-            "This may indicate the container failed to start or the Resonite engine initialization failed.");
+        if (!result)
+        {
+            var logs = await _fixture.GetLogsAsync();
+            Assert.Fail(
+                "Engine Ready! message was not found in container logs within 5 minutes. " +
+                "This may indicate the container failed to start or the Resonite engine initialization failed.\n" +
+                $"Container logs:\n{logs}");
+        }
     }
 }


### PR DESCRIPTION
## 概要
Resonite 2026.6.18.634 で `FrooxEngine.Engine.UpdateInput()` が headless 環境で NullReferenceException をスローするようになり、`Engine.UpdateStep` が `InputUpdate` ステージから進めなくなった結果、`Application startup complete` ログに到達せず CI のインテグレーションテストがタイムアウトしていた ([失敗した run](https://github.com/hantabaru1014/baru-reso-headless-container/actions/runs/27754431416))。

## 修正内容
- `EnginePrePatcher/Patches/NoOpUpdateInput.cs`: Cecil で `Engine.UpdateInput()` の本体を no-op に置き換え。headless では `InitializeInputDrivers` が `HeadOutputDevice.Headless` のときに input driver を一切登録しないため、UpdateInput を呼ばないことによる副作用はない。
- `Headless.Tests/IntegrationTests/ContainerStartupTests.cs`: タイムアウト時にコンテナログを assert message に含めるようにし、再現性のあるエラー診断ができるよう改善。

## 検証
- ローカル (WSL/Linux, Debug ビルド) でパッチ前は `Engine Ready!` 後に `Exception when running engine update step. Stage: InputUpdate` がループし、`Application startup complete` が出ない状態を再現。
- パッチ後は `Application startup complete` まで到達することを確認。

## Test plan
- [ ] PR Test (amd64) でインテグレーションテストが pass
- [ ] PR Test (arm64) でインテグレーションテストが pass